### PR TITLE
Subtree acls

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ This configuration works on a Fedora and Ubuntu host for a filesystem deployment
         "storage_backend": "filesystem",
         "storage_path": "/var/www/hatrac",
         "database_type": "postgres",
-        "database_name": "",
+        "database_dsn": "dbname=hatrac",
         "database_schema": "hatrac",
         "database_max_retries": 5
     }
@@ -93,7 +93,7 @@ This configuration works for an Amazon AWS S3 deployment:
     	    "aws_secret_access_key": <AWS_SECRET_ACCESS_KEY>
         },
         "database_type": "postgres",
-        "database_name": "",
+        "database_dsb": "dbname=hatrac",
         "database_schema": "hatrac",
         "database_max_retries": 5
     }
@@ -145,7 +145,7 @@ the same cookie name and path settings):
     
           "database_schema": "webauthn2", 
           "database_type": "postgres", 
-          "database_name": "ermrest", 
+          "database_dsn": "dname=ermrest", 
           "database_max_retries": 5
     }
 

--- a/REST-API.md
+++ b/REST-API.md
@@ -579,14 +579,18 @@ name or the `*` wildcard.  The full set of access control lists for
 each resource type is:
 - Namespace
   - `owner`: lists roles considered to be owners of the namespace.
-  - `create`: lists roles permitted to create new children in the
-    namespace.
+  - `create`: lists roles permitted to create new children in the namespace.
+  - `subtree-owner`: lists roles considered to be owners of the namespace or any namespace, object, or object version beneath the namespace.
+  - `subtree-create`: lists roles permitted to create new children of the namespace or of any namespace beneath the namespace.
+  - `subtree-update`: lists roles permitted to update data on any object beneath the namespace.
+  - `subtree-read`: lists roles permitted to read any object version beneath the namespace.
 - Object
   - `owner`: lists roles considered to be owners of the object.
   - `update`: lists roles permitted to update object with new versions.
+  - `subtree-owner`: lists roles considered to be owners of any object version for the object.
+  - `subtree-read`: lists roles permitted to read any object version for the object.
 - Object Version
-  - `owner`: lists roles considered to be owners of the object
-    version.
+  - `owner`: lists roles considered to be owners of the object version.
   - `read`: lists roles permitted to read the object version.
 
 ### Lifecycle and Ownership

--- a/REST-API.md
+++ b/REST-API.md
@@ -583,8 +583,7 @@ each resource type is:
     namespace.
 - Object
   - `owner`: lists roles considered to be owners of the object.
-  - `create`: lists roles permitted to create new versions of the
-    object.
+  - `update`: lists roles permitted to update object with new versions.
 - Object Version
   - `owner`: lists roles considered to be owners of the object
     version.

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -376,6 +376,7 @@ CREATE TABLE hatrac.name (
   is_deleted bool NOT NULL,
   owner text[],
   "create" text[],
+  "update" text[],
   read text[]
 );
 

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -982,7 +982,8 @@ VALUES (%(uploadid)s, %(position)s, %(aux)s)
         else:
             pattern = "n.name ~ %s" % sql_literal("^" + regexp_escape(resource.name) + '/')
         return db.select(
-            ['hatrac.name n', 'hatrac.version v'], 
+            ['hatrac.name n', 'hatrac.version v'],
+            what=','.join(['n.name', 'v.*'] + list(ancestor_acl_sql(['owner', 'read']))),
             where=' AND '.join([
                 "v.nameid = n.id",
                 pattern,
@@ -999,7 +1000,8 @@ VALUES (%(uploadid)s, %(position)s, %(aux)s)
         if not recursive:
             pattern += '[^/]+$'
         return db.select(
-            ['hatrac.name n'], 
+            ['hatrac.name n'],
+            what=','.join(['n.*'] + list(ancestor_acl_sql(['owner', 'update', 'read', 'create']))),
             where=' AND '.join([
                 "n.name ~ %s" % sql_literal(pattern),
                 "NOT n.is_deleted"
@@ -1014,7 +1016,7 @@ VALUES (%(uploadid)s, %(position)s, %(aux)s)
             pattern = "n.name ~ %s" % sql_literal("^" + regexp_escape(resource.name) + '/')
         return db.select(
             ['hatrac.name n', 'hatrac.upload u'], 
-            what="u.*, n.name",
+            what=','.join(["u.*", "n.name"] + list(ancestor_acl_sql(['owner']))),
             where=' AND '.join([
                 "u.nameid = n.id",
                 pattern

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -214,7 +214,7 @@ class HatracNamespace (HatracName):
 
 class HatracObject (HatracName):
     """Represent a bound object."""
-    _acl_names = ['owner', 'create', 'read']
+    _acl_names = ['owner', 'update', 'read']
 
     def __init__(self, directory, **args):
         HatracName.__init__(self, directory, **args)
@@ -553,7 +553,7 @@ class HatracDirectory (DatabaseConnection):
         self._delete_version(db, resource)
         return lambda : self.storage.delete(resource.name, resource.version)
 
-    @db_wrap(reload_pos=1, enforce_acl=(1, 2, ['owner', 'create']))
+    @db_wrap(reload_pos=1, enforce_acl=(1, 2, ['owner', 'update']))
     def create_version(self, object, client_context, nbytes=None, content_type=None, content_md5=None, db=None):
         """Create, persist, and return a HatracObjectVersion instance.
 

--- a/test/smoketest.py
+++ b/test/smoketest.py
@@ -24,7 +24,7 @@ if deployment == FILESYSTEM:
             "storage_backend": "filesystem",
             "storage_path": os.getcwd() + "/hatrac_test_data",
             "database_type": "postgres",
-            "database_name": os.environ.get("HATRAC_TEST_DB", "hatrac_test"),
+            "database_dsn": "dbname=" + os.environ.get("HATRAC_TEST_DB", "hatrac_test"),
             "database_schema": "hatrac",
             "database_max_retries": 5
         }
@@ -36,7 +36,7 @@ else:
             "service_prefix": "/hatrac",
             "storage_backend": "amazons3",
             "database_type": "postgres",
-            "database_name": os.environ.get("HATRAC_TEST_DB", "hatrac_test"),
+            "database_dsn": "dbname=" + os.environ.get("HATRAC_TEST_DB", "hatrac_test"),
             "database_schema": "hatrac",
             "database_max_retries": 5,
             "s3_bucket" : os.environ.get("HATRAC_TEST_BUCKET", "hatractest"),

--- a/test/smoketest.py
+++ b/test/smoketest.py
@@ -62,6 +62,9 @@ anon_context = Context()
 foo_context = Context()
 foo_context.client = 'foo'
 
+foo2_context = Context()
+foo2_context.client = 'foo2'
+
 def expect(cls, thunk):
     got_expected = False
     try:
@@ -92,6 +95,7 @@ test_directory.create_name("/foo", False, root_context)
 test_directory.create_name("/foo/bar", False, root_context)
 test_directory.create_name("/foo/obj1", True, root_context)
 test_directory.create_name("/foo/objJ", True, root_context)
+rootns = test_directory.name_resolve("/")
 obj1 = test_directory.name_resolve("/foo/obj1")
 objJ = test_directory.name_resolve("/foo/objJ")
 
@@ -212,8 +216,24 @@ vers1.set_acl('read', ['foo', 'bar'], root_context)
 
 ''.join(obj1.get_content(foo_context)[3])
 
+expect(
+    hatrac.core.Forbidden,
+    lambda : ''.join(obj1.get_content(foo2_context)[3])
+)   
+
+rootns.set_acl_role('subtree-read', 'foo2', root_context)
+
+''.join(obj1.get_content(foo2_context)[3])
+
 vers1.set_acl_role('read', 'baz', root_context)    
 vers1.drop_acl_role('read', 'bar', root_context)
+
+obj1.set_acl_role('owner', 'foo2', root_context)
+
+expect(
+    hatrac.core.Forbidden,
+    lambda : obj1.delete(foo2_context)
+)
 
 expect(
     hatrac.core.NotFound,
@@ -222,5 +242,8 @@ expect(
 
 obj1.clear_acl('read', root_context)
 
-obj1.delete(root_context)
+obj1.set_acl_role('subtree-owner', 'foo2', foo2_context)
+
+obj1.delete(foo2_context)
+
 


### PR DESCRIPTION
These patches add preliminary support for subtree-* ACL variants to allow simpler management of project trees and other data sharing where many resources will share the same policies. Additional test cases need to be written before we merge this, but I am starting the pull request to make it easier to review and discuss, since we may decide to abandon this approach and try something different...

These changes also raise several questions:
- Should we really have separate ACL tables linked to the resources, since ACLs may become quite sparse when using tree-level policies?  The current denormalized arrays seem pretty ugly.
- When creating new resources, should we still always set the `owner` ACL to the client identity, even if the client is already present in the `subtree-owner` ACL of an ancestor resource?  Skipping this might streamline some bulk workloads, but of course the ancestor ACLs could change in the future, orphaning such resources that lack their own owner.