### PR TITLE
Replace DB driver

### DIFF
--- a/hatrac/__init__.py
+++ b/hatrac/__init__.py
@@ -18,7 +18,10 @@ def instantiate(config):
     return directory
 
 # instantiate a default singleton
-directory = instantiate(core.config)
+try:
+    directory = instantiate(core.config)
+except psycopg2.OperationalError:
+    directory = None
 
 # TODO: conditionalize this if we ever have alternate directory impls
 def deploy_cli(argv, config=None):

--- a/hatrac/__init__.py
+++ b/hatrac/__init__.py
@@ -8,6 +8,7 @@ import sys
 import core
 import model
 import rest
+import psycopg2
 
 def instantiate(config):
     """Return a directory service instance for config."""

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -596,7 +596,7 @@ class PooledConnection (object):
         self.used_pool = pools[dsn]
         self.conn = self.used_pool.getconn()
         self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_REPEATABLE_READ)
-        self.cur = self.conn.cursor()
+        self.cur = self.conn.cursor(cursor_factory=DictCursor)
 
     def perform(self, bodyfunc, finalfunc=lambda x: x, verbose=False):
         """Run bodyfunc(conn, cur) using pooling, commit, transform with finalfunc, clean up.
@@ -833,7 +833,7 @@ WHERE c.id = c2.id
         # prepare statements again since they would have failed prior to above deploy SQL steps...
         self.pc.conn._prepare_hatrac_stmts()
 
-        rootns = HatracNamespace(self, **dict((self._name_lookup(conn, cur, '/'))))
+        rootns = HatracNamespace(self, **(self._name_lookup(conn, cur, '/')))
 
         for role in admin_roles:
             self._set_resource_acl_role(conn, cur, rootns, 'owner', role)

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -833,7 +833,7 @@ WHERE c.id = c2.id
         # prepare statements again since they would have failed prior to above deploy SQL steps...
         self.pc.conn._prepare_hatrac_stmts()
 
-        rootns = HatracNamespace(self, **(self._name_lookup(conn, cur, '/')))
+        rootns = HatracNamespace(self, **dict((self._name_lookup(conn, cur, '/'))))
 
         for role in admin_roles:
             self._set_resource_acl_role(conn, cur, rootns, 'owner', role)

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -71,9 +71,9 @@ logger.addHandler(sysloghandler)
 logger.setLevel(logging.INFO)
 
 # some log message templates
-log_template = "%(elapsed_s)d.%(elapsed_ms)3.3ds %(client_ip)s user=%(client_identity)s req=%(reqid)s"
+log_template = "%(elapsed_s)d.%(elapsed_frac)4.4ds %(client_ip)s user=%(client_identity)s req=%(reqid)s"
 log_trace_template = log_template + " -- %(tracedata)s"
-log_final_template = log_template + " (%(status)s) %(method)s %(proto)s://%(host)s/%(uri)s %(range)s %(type)s"
+log_final_template = log_template + " (%(status)s) %(method)s %(proto)s://%(host)s%(uri)s %(range)s %(type)s"
 
 def log_parts():
     """Generate a dictionary of interpolation keys used by our logging template."""
@@ -84,7 +84,7 @@ def log_parts():
         client_identity = json.dumps(client_identity, separators=(',',':'))
     parts = dict(
         elapsed_s = elapsed.seconds, 
-        elapsed_ms = elapsed.microseconds/1000,
+        elapsed_frac = elapsed.microseconds/100,
         client_ip = web.ctx.ip,
         client_identity = urllib.quote(client_identity),
         reqid = web.ctx.hatrac_request_guid
@@ -248,6 +248,9 @@ class RestHandler (object):
         self.http_etag = None
         self.http_vary = _webauthn2_manager.get_http_vary()
 
+    def trace(self, msg):
+        web.ctx.hatrac_request_trace(msg)
+        
     def _fullname(self, path, name):
         nameparts = [ n for n in ((path or '') + (name or '')).split('/') if n ]
         fullname = '/' + '/'.join(nameparts)

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -211,8 +211,8 @@ def web_method():
 
             try:
                 # run actual method
-                for buf in original_method(*args):
-                    yield buf
+                return original_method(*args)
+
             except hatrac.core.BadRequest, ev:
                 raise BadRequest(str(ev))
             except hatrac.core.Unauthenticated, ev:
@@ -474,9 +474,7 @@ class RestHandler (object):
         if self.http_vary:
             web.header('Vary', ', '.join(self.http_vary))
 
-        if self.get_body:
-            for buf in data_generator:
-                yield buf
+        return data_generator
 
     def create_response(self, resource):
         """Form response for resource creation request."""


### PR DESCRIPTION
This PR drops the web.database API and uses psycopg2 directly. It uses the `DictCursor` extension to make row data more compatible with previous expectations in the codebase.  It then uses the new connections to prepare statements for the frequently used SQL to amortize planner costs a bit.  In micro-benchmarks this nearly doubles the request throughput for GET on very small objects.

At this point, the next biggest latency source is webauthn, so it doesn't seem worthwhile to perform further tuning on Hatrac before we address that.  We're still at least 5x slower than static files in Apache for very small objects (like pyramidal image tiles).

The ugliest code is the new connection pool stuff, cribbed heavily from ERMrest but modified here to do the locally custom connection with prepared statements. I don't want to try to factor out a common idiom here beyond what psycopg2 already has. If we ever rework the DB layer in webauthn, perhaps we can find some common bits to share across our projects again, but it's not really that much code.

This code should work as a software-only update on an existing deployment and also to deploy a new system from scratch.  It would be good for @robes to validate that too even though I've done it on my workstation.