### PR TITLE
Metadata sub-resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: required
 dist: trusty
 
 addons:
-  postgresq: "9.4"
+  postgresql: "9.5"
 
 env:
   global:
@@ -16,10 +16,10 @@ env:
 before_install:
   - sudo apt-get -y update
   - sudo service postgresql stop
-  - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3
+  - sudo apt-get -y purge postgresql-9.1 postgresql-9.2 postgresql-9.3 postgresql-9.4
   - sudo apt-get -y install libpq-dev postgresql-server-dev-9.4 python-dev
-  - sudo service postgresql start 9.4
-  - sudo apt-get -y install apache2 apache2-dev libjson-c-dev postgresql-9.4 ssl-cert libapache2-mod-wsgi python python-dateutil python-tz
+  - sudo apt-get -y install apache2 apache2-dev libjson-c-dev postgresql-9.5 ssl-cert libapache2-mod-wsgi python python-dateutil python-tz
+  - sudo service postgresql start 9.5
   - sudo apt-get -y purge python-psycopg2
   - sudo pip install web.py
   - sudo pip install psycopg2

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ distribution with Python 2.6. It has a conventional web service stack:
 - mod_wsgi 
 - web.py lightweight web framework
 - psycopg2 database driver
-- PostgreSQL 9.x
+- PostgreSQL 9.5 or newer
 - webauthn2 security adaptation layer (another product of our group)
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ model with:
 
 [![Build Status](https://travis-ci.org/informatics-isi-edu/hatrac.svg)](https://travis-ci.org/informatics-isi-edu/hatrac)
 
-Hatrac is currently under rapid development, with an expectation to
-have a stable release sometime in 2015.
+Hatrac is research software but runs in production for several
+informatics projects using the filesystem storage backend. It is
+developed in a continuous-integration style with an automated
+regression test suite covering all core API features.
 
 ## Using Hatrac
 
@@ -39,7 +41,7 @@ deployment.
 ### Prerequisites
 
 Hatrac is developed and tested primarily on an enterprise Linux
-distribution with Python 2.6. It has a conventional web service stack:
+distribution with Python 2.7. It has a conventional web service stack:
 - Apache HTTPD
 - mod_wsgi 
 - web.py lightweight web framework

--- a/REST-API.md
+++ b/REST-API.md
@@ -337,16 +337,38 @@ configuration is provided as input:
     Content-Type: content_type
     Content-Length: N
     Content-MD5: hash_value
+	Content-SHA256: hash_value
+	Content-Disposition: filename*=UTF-8''filename
 	If-Match: etag_value
 	If-None-Match: *
     
     ...content...
 
-The optional `If-Match` and `If-None-Match` headers MAY be specified to limit object update to specific scenarios. In a normal situation, only one of these two headers is specified in a single request:
+The optional `If-Match` and `If-None-Match` headers MAY be specified
+to limit object update to specific scenarios. In a normal situation,
+only one of these two headers is specified in a single request:
   - An _etag value_ with the `If-Match` header requires that the current version of the object on the server match the version indicated by the _etag value_ in order for the object to be updated as per the request _content_.
   - An `*` with the `If-None-Match` header requires that the object lack a current version on the server in order for the object to be created or updated as per the request _content_.
 
-Without either `If-Match` or `If-None-Match` headers in the request, the update will be unconditionally applied if allowed by policy and the current state of the server.
+Without either `If-Match` or `If-None-Match` headers in the request,
+the update will be unconditionally applied if allowed by policy and
+the current state of the server.
+
+The optional `Content-MD5` and `Content-SHA256` headers can carry an
+MD5 or SHA-256 _hash value_, respectively. The _hash value_ MUST be
+the base64 encoded representation of the underlying bit sequence
+defined by the relevant hash algorithm standard. Either or both, if
+supplied, will be stored and returned with data retrieval responses,
+useful for end-to-end data integrity checks by clients. An
+implementation MAY validate the supplied _content_ and reject the
+request if it mismatches any supplied _hash value_.
+
+The optional `Content-Disposition` header will be stored and returned
+with data retrieval responses. An implementation MAY restrict which
+values are acceptable as content disposition instructions. Every
+implementation SHOULD support the `filename*=UTF-8''` _filename_
+syntax where _filename_ is a basename with no path separator
+characters.
 
 A successful response is:
 
@@ -357,11 +379,9 @@ A successful response is:
     
     /namespace_path/object_name:version_id
 
-The optional `Content-MD5` header can carry an MD5 _hash value_ which
-will be stored and used for data integrity checks.  The successful
-response includes the _version id_ qualified name of the newly updated
-object.
-    
+The successful response includes the _version id_ qualified name of
+the newly updated object.
+
 Typical PUT error responses would be:
   - **400 Bad Request**: the client supplied a `Content-MD5` header
       with a _hash value_ that does not match the entity _content_
@@ -416,13 +436,16 @@ for which a successful response is:
     Content-Type: content_type
     Content-Length: N
     Content-MD5: hash_value
+	Content-SHA256: hash_value
+	Content-Disposition: filename*=UTF-8''filename
     ETag: etag_value
     
     ...content...
 
-The optional `Content-MD5` header MUST be present if it was supplied
-during object creation and MAY be present if the service computes
-missing checksums in other cases.
+The optional `Content-MD5`, `Content-SHA256`, and
+`Content-Disposition` headers MUST be present if supplied during
+object creation and MAY be present if the service computes missing
+values in other cases.
 
 It is RECOMMENDED that a Hatrac server return an `ETag` indicating the version of the _content_ returned to the client.
     
@@ -451,6 +474,8 @@ for which a successful response is:
     Content-Type: content_type
     Content-Length: N
     Content-MD5: hash_value
+	Content-SHA256: hash_value
+	Content-Disposition: filename*=UTF-8''filename
 
 The HEAD operation is essentially equivalent to the GET operation but
 with the actual object content elided.
@@ -535,6 +560,8 @@ for which the successful response is:
     200 OK
     Content-Type: content_type
     Content-MD5: hash_value
+	Content-SHA256: hash_value
+	Content-Disposition: filename*=UTF-8''filename
     Content-Length: N
 	ETag: etag_value
     
@@ -558,6 +585,8 @@ for which the successful response is:
     200 OK
     Content-Type: content_type
     Content-MD5: hash_value
+	Content-SHA256: hash_value
+	Content-Disposition: filename*=UTF-8''filename
     Content-Length: N
     
 with the same interpretation as documented for Object Metadata

--- a/REST-API.md
+++ b/REST-API.md
@@ -17,8 +17,9 @@ This documentation is broken down into the following general topics:
 4. [Nested Namespaces](#nested-namespace-resources)
 5. [Objects](#object-resources)
 6. [Object Versions](#object-version-resources)
-7. [Access Control Lists](#access-control-list-sub-resources)
-8. [Chunked Uploads](#chunked-upload-resources)
+7. [Metadata](#metadata-sub-resources)
+8. [Access Control Lists](#access-control-list-sub-resources)
+9. [Chunked Uploads](#chunked-upload-resources)
 
 ### Quick Links to Operations
 
@@ -37,11 +38,16 @@ The REST API supports the following operations.
   - [Create object version](#object-creation-and-update)
   - [Get object version content](#object-version-retrieval)
   - [Delete object version](#object-version-deletion)
-4. Access control list operations
+4. Metadata management operations
+  - [Get metadata collection](#metadata-collection-retrieval)
+  - [Get metadata value](#metadata-value-retrieval)
+  - [Create or update metadata value](#metadata-value-creation-and-update)
+  - [Delete metadata value](#metadata-value-deletion)
+5. Access control list operations
   - [Get access controls](#access-control-retrieval)
   - [Update access control list](#access-control-list-update)
   - [Clear access control list](#access-control-list-deletion)
-5. Chunked upload operations
+6. Chunked upload operations
   - [Get upload job listing](#chunked-upload-job-listing-retrieval)
   - [Create upload job](#chunked-upload-job-creation)
   - [Get upload job status](#chunked-upload-job-status-retrieval)
@@ -625,6 +631,114 @@ version:
   - An object may be left empty, i.e. with no current version, if all
     versions have been deleted.  A subsequent update can reintroduce
     content for the object.
+
+## Metadata Sub-Resources
+
+The service also exposes sub-resources for metadata management on
+existing object versions:
+
+- https:// _authority_ / _resource name_ ;metadata
+- https:// _authority_ / _resource name_ ;metadata/ _fieldname_
+
+Where _resource name_ is currently restricted to object version names
+as described above. The _fieldname_ is a lower-case string which
+matches an HTTP request header suitable for describing content
+metadata. The currently recognized _fieldnames_ include:
+
+- `content-type`
+- `content-disposition`
+- `content-md5`
+- `content-sha256`
+
+### Lifecycle and Ownership
+
+Metadata are sub-resources of the main resource identified in the
+_resource name_ in the URL, and their lifetime is bounded by the
+lifetime of that main resource.
+
+1. Initial metadata MAY be specified during object creation and update.
+2. Immutable checksums MAY be added on existing object versions.
+3. Mutable metadata MAY be added, removed, or modified on existing object versions.
+
+### Metadata Collection Retrieval
+
+The GET operation is used to retrieve all metadata sub-resources en masse
+as a document:
+
+    GET /resource_name;metadata
+	Host: authority_name
+	Accept: application/json
+	If-None-Match: etag_value
+	
+for which the successful response is:
+
+    200 OK
+	Content-Type: application/json
+	Content-Length: N
+	ETag: etag_value
+	
+	{"content-type": content_type, 
+	 "content-md5": hash_value,
+	 "content-sha256": hash_value,
+	 "content-disposition": disposition}
+
+The standard
+[object version metadata retrieval](#object-version-metadata-retrieval),
+operation uses the `HEAD` method on the main resource to retrieve this
+same metadata as HTTP response headers.
+
+### Metadata Value Retrieval
+
+The GET operation is used to retrieve one metadata sub-resource as a
+text value:
+
+    GET /resource_name;metadata/fieldname
+	Host: authority_name
+	Accept: text/plain
+	If-None-Match: etag_value
+	
+for which the successful response is:
+
+    200 OK
+	Content-Type: text/plain
+	Content-Length: N
+	ETag: etag_value
+	
+	value
+
+The textual _value_ is identical to what would be present in the HTTP
+response header value when retrieving the main resource content.
+
+### Metadata Value Creation and Update
+
+The PUT operation is used to create or update one metadata sub-resource as a
+text value:
+
+    PUT /resource_name;metadata/fieldname
+	Host: authority_name
+	Content-Type: text/plain
+	If-Match: etag_value
+
+	value
+
+for which the successful response is:
+
+    204 No Content
+
+The textual _value_ is identical to what would be present in the HTTP
+request header value when creating the main resource content.
+
+### Metadata Value Deletion
+
+The DELETE operation is used to create or update one metadata sub-resource as a
+text value:
+
+    DELETE /resource_name;metadata/fieldname
+	Host: authority_name
+
+for which the successful response is:
+
+    204 No Content
 
 ## Access Control List Sub-Resources
 

--- a/hatrac/__init__.py
+++ b/hatrac/__init__.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/__init__.py
+++ b/hatrac/__init__.py
@@ -38,6 +38,7 @@ def deploy_cli(argv, config=None):
     if len(argv) > 1:
         root_roles = argv[1:]
         deploy_dir.deploy_db(root_roles)
+        deploy_dir.schema_upgrade()
         return 0
     else:
         sys.stderr.write("""

--- a/hatrac/core.py
+++ b/hatrac/core.py
@@ -129,6 +129,11 @@ class Metadata (dict):
             _make_bin_decoder(32, ' for content-sha256')
         )
     }
+
+    def __init__(self, src={}):
+        dict.__init__(self)
+        for k, v in src.items():
+            self[k] = v
     
     def is_object(self):
         return False

--- a/hatrac/core.py
+++ b/hatrac/core.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -399,22 +399,21 @@ class HatracUpload (HatracName):
     def get_content(self, client_context, get_data=True):
         self.enforce_acl(['owner'], client_context)
         metadata = self.metadata.to_http()
-        # TODO: generalize for all hashes?
-        body = dict(
-            url=str(self), 
-            target=str(self.object), 
-            owner=self.get_acl('owner'),
-            chunksize=self.chunksize,
-            nbytes=self.nbytes
-        )
-        for hdr, field in [
-                ('content-type', 'content_type'),
-                ('content-md5', 'content_md5'),
-                ('content-sha256', 'content_sha256'),
-                ('content-disposition', 'content_disposition')
-        ]:
+        body = {
+            'url': str(self), 
+            'target': str(self.object), 
+            'owner': self.get_acl('owner'),
+            'chunk-length': self.chunksize,
+            'content-length': self.nbytes
+        }
+        for hdr in {
+                'content-type',
+                'content-md5',
+                'content-sha256',
+                'content-disposition',
+        }:
             if hdr in metadata:
-                body[field] = metadata[hdr]
+                body[hdr] = metadata[hdr]
         body = jsonWriterRaw(body) + '\n'
         return len(body), Metadata({'content-type': 'application/json'}), body
 

--- a/hatrac/model/storage/amazons3.py
+++ b/hatrac/model/storage/amazons3.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/model/storage/filesystem.py
+++ b/hatrac/model/storage/filesystem.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/model/storage/filesystem.py
+++ b/hatrac/model/storage/filesystem.py
@@ -77,7 +77,7 @@ class HatracStorage (object):
 
         return (dirname, relname)
 
-    def create_from_file(self, name, input, nbytes, content_type=None, content_md5=None):
+    def create_from_file(self, name, input, nbytes, metadata={}):
         """Create an entire file-version object from input content, returning version ID."""
         
         version = base64.b32encode( 
@@ -89,10 +89,10 @@ class HatracStorage (object):
         f = make_file(dirname, relname, 'wb')
 
         # upload whole content at offset 0 (for code reuse)
-        self.upload_chunk_from_file(None, None, 0, 0, input, nbytes, content_md5, f)
+        self.upload_chunk_from_file(None, None, 0, 0, input, nbytes, metadata, f)
         return version
 
-    def create_upload(self, name, nbytes=None, content_type=None, content_md5=None):
+    def create_upload(self, name, nbytes=None, metadata={}):
         upload_id = self.create_from_file(name, StringIO(''), 0)
         return upload_id
 
@@ -101,13 +101,13 @@ class HatracStorage (object):
         self.delete(name, upload_id)
         return None
 
-    def finalize_upload(self, name, upload_id, chunk_data, content_md5=None):
+    def finalize_upload(self, name, upload_id, chunk_data, metadata={}):
         # nothing changes in storage for this backend strategy
         version_id = upload_id
         assert chunk_data is None
 
         # aggressively validate uploaded content against pre-defined MD5 if it was given at job start
-        if content_md5 is not None:
+        if 'content-md5' in metadata:
             dirname, relname = self._dirname_relname(name, version_id)
             fullname = "%s/%s" % (dirname, relname)
             f = open(fullname, "rb")
@@ -123,15 +123,15 @@ class HatracStorage (object):
                     eof = True
 
             stored_md5 = hasher.digest()
-            if content_md5 != stored_md5:
+            if metadata['content-md5'] != stored_md5:
                 raise Conflict(
                     'Current uploaded content MD5 %s does not match expected %s.'
-                    % (binascii.hexlify(stored_md5), binascii.hexlify(content_md5))
+                    % (binascii.hexlify(stored_md5), binascii.hexlify(metadata['content-md5']))
                 )
         
         return version_id
 
-    def upload_chunk_from_file(self, name, version, position, chunksize, input, nbytes, content_md5=None, f=None):
+    def upload_chunk_from_file(self, name, version, position, chunksize, input, nbytes, metadata={}, f=None):
         """Save chunk data into storage.
 
            If self.track_chunks, return value must be None or a value
@@ -146,7 +146,7 @@ class HatracStorage (object):
             f = open(fullname, "r+b")
         f.seek(position*chunksize)
 
-        if content_md5:
+        if 'content-md5' in metadata:
             hasher = hashlib.md5()
         else:
             hasher = None
@@ -178,19 +178,19 @@ class HatracStorage (object):
 
         if hasher:
             received_md5 = hasher.digest()
-            if content_md5 != received_md5:
+            if metadata['content-md5'] != received_md5:
                 raise BadRequest(
                     'Received content MD5 %s does not match expected %s.' 
-                    % (binascii.hexlify(received_md5), binascii.hexlify(content_md5))
+                    % (binascii.hexlify(received_md5), binascii.hexlify(metadata['content-md5']))
                 )
 
         return "test"
                
-    def get_content(self, name, version, content_md5=None):
-        return self.get_content_range(name, version, content_md5)
+    def get_content(self, name, version, metadata={}):
+        return self.get_content_range(name, version, metadata)
      
-    def get_content_range(self, name, version, content_md5=None, get_slice=None):
-        """Return (nbytes, content_type, content_md5, data_iterator) tuple for existing file-version object."""
+    def get_content_range(self, name, version, metadata={}, get_slice=None):
+        """Return (nbytes, metadata, data_iterator) tuple for existing file-version object."""
         dirname, relname = self._dirname_relname(name, version)
         fullname = "%s/%s" % (dirname, relname)
         nbytes = os.path.getsize(fullname)
@@ -203,13 +203,13 @@ class HatracStorage (object):
             limit = nbytes
 
         if pos != 0 or limit != nbytes:
-            # cannot integrity-check a partial read
-            content_md5 = None
-        
+            # object metadata does not apply to partial read content
+            metadata = {}
+            
         length = limit - pos
 
         def helper():
-            if content_md5:
+            if 'content-md5' in metadata:
                 hasher = hashlib.md5()
             else:
                 hasher = None
@@ -233,15 +233,15 @@ class HatracStorage (object):
 
                     if eof and hasher:
                         retrieved_md5 = hasher.digest()
-                        if content_md5 != retrieved_md5:
+                        if metadata['content-md5'] != retrieved_md5:
                             raise IOError(
                                 'Retrieved content MD5 %s does not match expected %s.'
-                                % (binascii.hexlify(retrieved_md5), binascii.hexlify(content_md5))
+                                % (binascii.hexlify(retrieved_md5), binascii.hexlify(metadata['content-md5']))
                             )
 
                     yield buf
 
-        return (length, None, content_md5, helper())
+        return (length, metadata, helper())
 
     def delete(self, name, version):
         """Delete object version."""

--- a/hatrac/rest/__init__.py
+++ b/hatrac/rest/__init__.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/rest/__init__.py
+++ b/hatrac/rest/__init__.py
@@ -13,6 +13,7 @@ import core
 
 # these modify core.dispatch_rules
 import acl
+import metadata
 import name
 import transfer
 

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -29,15 +29,28 @@ from webauthn2.util import context_from_environment
 
 _webauthn2_manager = webauthn2.Manager()
 
+def hash_value(d):
+    return base64.b64encode(hashlib.md5(d).digest())
+
+def hash_multi(d):
+    if d is None:
+        return '_'
+    elif isinstance(d, (str, unicode)):
+        return hash_value(d)
+    elif isinstance(d, (list, set)):
+        return hash_list(d)
+    elif isinstance(d, dict):
+        return hash_dict(d)
+    else:
+        raise NotImplementedError('hash %s' % type(d))
+
 def hash_list(l):
-    copy = [ s.replace(';', ';;') for s in l ]
+    copy = [ hash_multi(s) for s in l ]
     copy.sort()
-    return base64.b64encode(hashlib.md5(';'.join(copy)).digest())
+    return hash_value(''.join(copy))
 
 def hash_dict(d):
-    copy = [ (k, hash_list(v)) for k, v in d.items() ]
-    copy.sort(key=lambda p: p[0])
-    return ";".join([ v for k, v in copy ])
+    return hash_list([ hash_multi(k) + hash_multi(v) for k, v in d.items() ])
 
 # map URL pattern (regexp) to handler class
 dispatch_rules = dict()

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -447,7 +447,7 @@ class RestHandler (object):
                 pass
 
         if get_slice is not None:
-            nbytes, content_type, content_md5, data_generator \
+            nbytes, metadata, data_generator \
                 = resource.get_content_range(client_context, get_slice, get_data=self.get_body)
             web.ctx.status = '206 Partial Content'
             web.header(
@@ -455,20 +455,21 @@ class RestHandler (object):
                 % (get_slice.start, get_slice.stop - 1, resource.nbytes)
             )
         else:
-            nbytes, content_type, content_md5, data_generator = resource.get_content(client_context, get_data=self.get_body)
+            nbytes, metadata, data_generator = resource.get_content(client_context, get_data=self.get_body)
             web.ctx.status = '200 OK'
 
-        if resource.is_object() and resource.is_version():
+        web.header('Content-Length', nbytes)
+
+        metadata = hatrac.core.Metadata(metadata).to_http()
+        for hdr, val in metadata.items():
+            web.header(hdr, val)
+
+        if resource.is_object() and resource.is_version() and 'content-disposition' not in resource.metadata:
             web.header('Content-Disposition', "filename*=UTF-8''%s" % urllib.quote(str(resource.object).split("/")[-1]))
             
-        web.header('Content-Length', nbytes)
-        if content_type:
-            web.header('Content-Type', content_type)
-        if content_md5:
-            assert len(content_md5) == 16
-            web.header('Content-MD5', base64.b64encode(content_md5))
         if self.http_etag:
             web.header('ETag', self.http_etag)
+            
         if self.http_vary:
             web.header('Vary', ', '.join(self.http_vary))
 

--- a/hatrac/rest/metadata.py
+++ b/hatrac/rest/metadata.py
@@ -1,0 +1,99 @@
+
+#
+# Copyright 2016 University of Southern California
+# Distributed under the Apache License, Version 2.0. See LICENSE for more info.
+#
+
+from core import web_url, web_method, RestHandler, NoMethod, Conflict, NotFound, BadRequest, hash_value, hash_dict
+from webauthn2.util import jsonWriterRaw, jsonReader
+import web
+
+@web_url([
+    # path, name, version, fieldname
+    '/((?:[^/:;]+/)*)([^/:;]+):([^/:;]+);metadata/([^/:;]+)',
+    '/((?:[^/:;]+/)*)([^/:;]+)();metadata/([^/:;]+)',
+    '/()()();metadata/([^/:;]+)'
+])
+class Metadata (RestHandler):
+
+    def __init__(self):
+        RestHandler.__init__(self)
+
+    @web_method()
+    def PUT(self, path, name, version, fieldname):
+        """Replace Metadata value."""
+        in_content_type = self.in_content_type()
+        if in_content_type != 'text/plain':
+            raise BadRequest('Only text/plain input is accepted for metadata.')
+
+        value = web.ctx.env['wsgi.input'].read()
+
+        resource = self.resolve_name_or_version(
+            path, name, version
+        )
+        if not resource.is_object():
+            raise NotFound('Namespaces do not have metadata sub-resources.')
+        resource = resource.get_current_version()
+        
+        self.set_http_etag(hash_value(resource.metadata.get(fieldname, '')))
+        self.http_check_preconditions('PUT')
+
+        resource.update_metadata(
+            web.ctx.hatrac_directory.metadata_from_http({ fieldname: value }),
+            web.ctx.webauthn2_context
+        )
+        return self.update_response()
+
+    @web_method()
+    def DELETE(self, path, name, version, fieldname):
+        """Clear Metadata value."""
+        resource = self.resolve_name_or_version(
+            path, name, version
+        )
+        if not resource.is_object():
+            raise NotFound('Namespaces do not have metadata sub-resources.')
+        resource = resource.get_current_version()
+
+        self.set_http_etag(hash_value(resource.metadata.get(fieldname, '')))
+        self.http_check_preconditions('DELETE')
+
+        resource.pop_metadata(
+            fieldname,
+            web.ctx.webauthn2_context
+        )
+        return self.update_response()
+
+    def _GET(self, path, name, version, fieldname):
+        """Get Metadata value."""
+        resource = self.resolve_name_or_version(path, name, version)
+        if not resource.is_object():
+            raise NotFound('Namespaces do not have metadata sub-resources.')
+        resource = resource.get_current_version().metadata[fieldname]
+
+        self.set_http_etag(hash_value(resource))
+        self.http_check_preconditions()
+        return self.get_content(resource, web.ctx.webauthn2_context)
+        
+
+@web_url([
+    # path, name, version
+    '/((?:[^/:;]+/)*)([^/:;]+):([^/:;]+);metadata/?',
+    '/((?:[^/:;]+/)*)([^/:;]+)();metadata/?',
+    '/()()();metadata/?'
+])
+class MetadataCollection (RestHandler):
+
+    def __init__(self):
+        RestHandler.__init__(self)
+
+    def _GET(self, path, name, version):
+        """Get Metadata collection."""
+        resource = self.resolve_name_or_version(path, name, version)
+        if not resource.is_object():
+            raise NotFound('Namespaces do not have metadata sub-resources.')
+        resource = resource.get_current_version().metadata
+
+        self.set_http_etag(hash_dict(resource))
+        self.http_check_preconditions()
+        return self.get_content(resource, web.ctx.webauthn2_context)
+

--- a/hatrac/rest/metadata.py
+++ b/hatrac/rest/metadata.py
@@ -28,12 +28,13 @@ class Metadata (RestHandler):
 
         value = web.ctx.env['wsgi.input'].read()
 
-        resource = self.resolve_name_or_version(
-            path, name, version
-        )
-        if not resource.is_object():
-            raise NotFound('Namespaces do not have metadata sub-resources.')
-        resource = resource.get_current_version()
+        if version:
+            resource = self.resolve_version(path, name, version)
+        else:
+            resource = self.resolve(path, name)
+            if not resource.is_object():
+                raise NotFound('Namespaces do not have metadata sub-resources.')
+            resource = resource.get_current_version()
         
         self.set_http_etag(hash_value(resource.metadata.get(fieldname, '')))
         self.http_check_preconditions('PUT')
@@ -47,12 +48,13 @@ class Metadata (RestHandler):
     @web_method()
     def DELETE(self, path, name, version, fieldname):
         """Clear Metadata value."""
-        resource = self.resolve_name_or_version(
-            path, name, version
-        )
-        if not resource.is_object():
-            raise NotFound('Namespaces do not have metadata sub-resources.')
-        resource = resource.get_current_version()
+        if version:
+            resource = self.resolve_version(path, name, version)
+        else:
+            resource = self.resolve(path, name)
+            if not resource.is_object():
+                raise NotFound('Namespaces do not have metadata sub-resources.')
+            resource = resource.get_current_version()
 
         self.set_http_etag(hash_value(resource.metadata.get(fieldname, '')))
         self.http_check_preconditions('DELETE')
@@ -65,10 +67,15 @@ class Metadata (RestHandler):
 
     def _GET(self, path, name, version, fieldname):
         """Get Metadata value."""
-        resource = self.resolve_name_or_version(path, name, version)
-        if not resource.is_object():
-            raise NotFound('Namespaces do not have metadata sub-resources.')
-        resource = resource.get_current_version().metadata[fieldname]
+        if version:
+            resource = self.resolve_version(path, name, version)
+        else:
+            resource = self.resolve(path, name)
+            if not resource.is_object():
+                raise NotFound('Namespaces do not have metadata sub-resources.')
+            resource = resource.get_current_version()
+
+        resource = resource.metadata[fieldname]
 
         self.set_http_etag(hash_value(resource))
         self.http_check_preconditions()
@@ -88,10 +95,15 @@ class MetadataCollection (RestHandler):
 
     def _GET(self, path, name, version):
         """Get Metadata collection."""
-        resource = self.resolve_name_or_version(path, name, version)
-        if not resource.is_object():
-            raise NotFound('Namespaces do not have metadata sub-resources.')
-        resource = resource.get_current_version().metadata
+        if version:
+            resource = self.resolve_version(path, name, version)
+        else:
+            resource = self.resolve(path, name)
+            if not resource.is_object():
+                raise NotFound('Namespaces do not have metadata sub-resources.')
+            resource = resource.get_current_version()
+
+        resource = resource.metadata
 
         self.set_http_etag(hash_dict(resource))
         self.http_check_preconditions()

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -1,6 +1,6 @@
 
 #
-# Copyright 2015 University of Southern California
+# Copyright 2015-2016 University of Southern California
 # Distributed under the Apache License, Version 2.0. See LICENSE for more info.
 #
 

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -8,7 +8,6 @@
 
 """
 
-import base64
 from core import web_url, web_method, RestHandler, NoMethod, Conflict, BadRequest, NotFound, LengthRequired, hash_list
 import hatrac.core
 import web
@@ -138,19 +137,20 @@ class Name (RestHandler):
                 nbytes = int(web.ctx.env['CONTENT_LENGTH'])
             except:
                 raise LengthRequired()
+
+            metadata = { 'content-type': in_content_type }
+            
             if 'HTTP_CONTENT_MD5' in web.ctx.env:
-                try:
-                    content_md5 = base64.b64decode(web.ctx.env.get('HTTP_CONTENT_MD5').strip())
-                except TypeError, e:
-                    raise BadRequest('Content-MD5 invalid header "%s": %s' % (web.ctx.env.get('HTTP_CONTENT_MD5').strip(), e))
-            else:
-                content_md5 = None
+                metadata['content-md5'] = web.ctx.env.get('HTTP_CONTENT_MD5').strip()
+
+            if 'HTTP_CONTENT_SHA256' in web.ctx.env:
+                metadata['content-sha256'] = web.ctx.env.get('HTTP_CONTENT_SHA256').strip()
+
             resource = resource.create_version_from_file(
                 web.ctx.env['wsgi.input'],
                 web.ctx.webauthn2_context,
                 nbytes,
-                content_type=in_content_type,
-                content_md5=content_md5
+                metadata=web.ctx.hatrac_directory.metadata_from_http(metadata)
             )
                 
         return self.create_response(resource)

--- a/test/rest-smoketest.sh
+++ b/test/rest-smoketest.sh
@@ -284,10 +284,10 @@ douploadtest()
     _md5="$2"
     shift 2
     cat > ${TEST_DATA} <<EOF
-{"chunk_bytes": ${chunk_bytes},
-"total_bytes": ${upload_total_bytes},
-"content_type": "application/x-bash",
-"content_md5": "${_md5}"}
+{"chunk-length": ${chunk_bytes},
+"content-length": ${upload_total_bytes},
+"content-type": "application/x-bash",
+"content-md5": "${_md5}"}
 EOF
 
     dotest "$1" "${_url};upload"  \


### PR DESCRIPTION
This generalizes the internal storage and handling of object metadata (sent as HTTP headers with object creation and retrieval) and adds a sub-resource api for managing metadata after the fact.

This is basically read to review and merge if acceptable for the filesystem backend. The S3 backend has been refactored for the same internal changes but not tested at all.

There are two compatibility changes I know about:
1. Now requiring Postgres 9.5 or later
2. The JSON representation of an existing upload job is changed to make it more consistent with the rest of the API. I don't think any clients actually look at this, since they usually create a job, send chunks, and finalize without ever needing to GET the upload job description.

@hongsudt please see the REST-API document updates since this covers features you requested
@robes or @mikedarcy do you think you can review the code changes at all?
@kylechard could you test on S3 and contribute fixes as needed (as well as review the other changes time permitting)?