### PR TITLE
sort the uris returned by negotiated_uris_list

### DIFF
--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -127,7 +127,7 @@ def negotiated_uri_list(parent, resources, metadata={}):
         ['application/json', 'text/uri-list', 'text/html'],
         'application/json'
     )
-    uris = [r.asurl() for r in resources]
+    uris = sorted([r.asurl() for r in resources])
     if metadata['content-type'] == 'text/uri-list':
         body = '\n'.join(uris) + '\n'
     elif metadata['content-type'] == 'text/html':


### PR DESCRIPTION
minor change to sort the list of uris returned by hatrac during a uri listing operation. the sorted ordering is common to say `ls` on linux and will make it easier to find things both for the few users that would be exposed to this but also for developers/admins that occasionally need to look at uri listings.