### PR TITLE
S3 functional update, redirect support, migration tools.

### DIFF
--- a/bin/hatrac-migrate
+++ b/bin/hatrac-migrate
@@ -1,0 +1,290 @@
+#!/usr/bin/python
+#
+# Copyright 2015-2021 University of Southern California
+# Distributed under the Apache License, Version 2.0. See LICENSE for more info.
+#
+import os
+import sys
+import datetime
+import shutil
+import argparse
+import base64
+import logging
+import traceback
+import requests
+from hatrac.core import config
+
+# do a run-time import of deriva-py so that we don't need to declare it as a formal dependency
+try:
+    from deriva.core import hatrac_store, format_exception, format_credential, get_transfer_summary, urlsplit, \
+        urlunsplit, make_dirs, BaseCLI, DEFAULT_CHUNK_SIZE
+    from deriva.core.utils import hash_utils
+except ModuleNotFoundError:
+    sys.stderr.write("Cannot import deriva.core python module. Ensure that deriva-py is installed.\n\n")
+    sys.exit(2)
+
+
+DESC = "DERIVA HATRAC Migration Tool"
+INFO = "For more information see: https://github.com/informatics-isi-edu/hatrac"
+VERSION = 0.1
+
+
+class HatracMigrateCLI (BaseCLI):
+    """Deriva Hatrac Migration Tool CLI.
+    """
+    cache_dir_name = "hatrac-migration-cache"
+
+    def __init__(self, description, epilog, version):
+        super(HatracMigrateCLI, self).__init__(description, epilog, version)
+        self.store = None
+        self.backend = None
+        self.credentials = None
+        self.path_prefix = "/hatrac"
+        self.cache_dir = "./%s" % self.cache_dir_name
+        self.headers = {'Connection': 'keep-alive'}
+        self.chunk_size = DEFAULT_CHUNK_SIZE
+        self.chunk_size_multiplier = 1
+
+        self.parser.add_argument("-l", "--link-redirects", action="store_true",
+                                 help="Set ALL object version redirect fields to: "
+                                 "{<host> + <path-prefix> + <existing object name>}")
+        self.parser.add_argument("-t", "--transfer-linked-redirects", action="store_true",
+                                 help="Transfer files that have linked redirects to this instance, "
+                                 "deleting link redirect on successful transfer completion.")
+        self.parser.add_argument("-p", "--path-prefix", metavar="</path>",
+                                 help="Base resource path prefix, defaults to '%s'" % self.path_prefix,
+                                 default=self.path_prefix)
+        self.parser.add_argument("-c", "--cache-dir", metavar="<path>",
+                                 help="Cache directory to use for transfers. Defaults to '%s'." % self.cache_dir)
+        self.parser.add_argument("-x", "--chunk-size-multiplier", metavar="<1-10>", type=int,
+                                 choices=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                                 help="Chunk size multiplier to use for chunked transfers. "
+                                      "Defaults to %dx of default chunk size %d bytes." %
+                                      (self.chunk_size_multiplier, self.chunk_size),
+                                 default=self.chunk_size_multiplier)
+
+    def transfer_linked_objects(self, directory):
+        objects = dict()
+        try:
+            root = directory.name_resolve("/")
+            names = directory.namespace_enumerate_names(root)
+            for name in names:
+                if name.is_object():
+                    versions = directory.object_enumerate_versions(name)
+                    for version in versions:
+                        url = version.aux.get("url")
+                        if url:
+                            objects[url] = version
+        except Exception as e:
+            raise RuntimeError(
+                "Exception while enumerating object versions from the database: %s" % format_exception(e))
+
+        for url, obj in objects.items():
+            logging.info("Attempting to transfer file(s)...")
+            if not self.store:
+                host = urlsplit(url)
+                self.store = hatrac_store.HatracStore(host.scheme, host.hostname, self.credentials)
+
+            # 1. GET the specified file from the remote hatrac system into the working cache.
+            success = False
+            cached = False
+            input_file = None
+            filename = os.path.basename(url)
+            resource_path = urlsplit(url).path
+            dirname = hash_utils.compute_hashes(resource_path.encode())['md5'][0]
+            output_dir = os.path.abspath(os.path.join(self.cache_dir, dirname))
+            file_path = os.path.abspath(os.path.join(output_dir, filename))
+            try:
+                resp = self.store.head(resource_path, self.headers)
+                file_size = int(resp.headers.get('Content-Length'))
+                file_md5 = resp.headers.get('Content-MD5') or ""
+                file_sha256 = resp.headers.get('Content-SHA256') or ""
+                if os.path.isfile(file_path):
+                    logging.info("Computing hashes for file %s found in local cache: [%s]." %
+                                 (filename, file_path))
+                    cached_file_size = os.path.getsize(file_path)
+                    cached_hashes = hash_utils.compute_file_hashes(file_path, ["md5", "sha256"])
+                    cached_md5 = cached_hashes["md5"][1]
+                    cached_sha256 = cached_hashes["sha256"][1]
+                    if (cached_file_size == file_size) and (cached_md5 == file_md5 or cached_sha256 == file_sha256):
+                        cached = True
+                    else:
+                        logging.warning("Cached file [%s] exists but does pass validation check. "
+                                        "Local file size: [%d]. Remote file size: [%d]. "
+                                        "Local file MD5: [%s]. Remote file MD5: [%s]. "
+                                        "Local file SHA256: [%s]. Remote file SHA256: [%s]."
+                                        % (file_path, cached_file_size, file_size, cached_md5, file_md5,
+                                           cached_sha256, file_sha256))
+                if not cached:
+                    logging.info("Transferring [%s] to: %s" % (url, file_path))
+                    make_dirs(output_dir, mode=0o755)
+                    self.store.get_obj(resource_path, self.headers, file_path)
+
+            except requests.HTTPError as e:
+                logging.error("File [%s] transfer failed: %s" % (file_path, e))
+                continue
+            except Exception as e:
+                logging.error(format_exception(e))
+                continue
+
+            # 2. Sanity check the checksums against the known object version checksums from the database.
+            md5 = base64.b64encode(obj.metadata.get("content-md5", b"")).decode()
+            if (md5 and file_md5) and (md5 != file_md5):
+                logging.warning(
+                    "Downloaded file MD5 [%s] does not equal known object version MD5 [%s]. Skipping." %
+                    (file_md5, md5))
+                continue
+            sha256 = base64.b64encode(obj.metadata.get("content-sha256", b"")).decode()
+            if (sha256 and file_sha256) and (sha256 != file_sha256):
+                logging.warning(
+                    "Downloaded file SHA256 [%s] does not equal known object version SHA256 [%s]. Skipping." %
+                    (file_sha256, sha256))
+                continue
+
+            # 3. Transfer the input file to the storage backend.
+            try:
+                if self.backend == "filesystem":
+                    version = obj.version
+                    dest_file_path = "%s/%s" % (directory.storage._dirname_relname(obj.name, version))
+                    make_dirs(dest_file_path, mode=0o755)
+                    logging.info("Moving file [%s] from local cache to [%s]." % (file_path, dest_file_path))
+                    shutil.move(file_path, dest_file_path)
+                else:
+                    input_file = open(file_path, "rb")
+
+                    # 3.1 Non-chunked transfer if under self.chunk_size
+                    if file_size < self.chunk_size:
+                        logging.info("Transferring file [%s] from local cache to backend storage type: [%s]." %
+                                     (file_path, self.backend))
+                        version = directory.storage.create_from_file(obj.name,
+                                                                     input_file,
+                                                                     file_size,
+                                                                     obj.metadata,
+                                                                     obj.version)
+                    # 3.2 Do chunked transfer.
+                    else:
+                        logging.info("Transferring file [%s] from local cache to backend storage using chunked "
+                                     "upload to backend storage type: [%s]." % (file_path, self.backend))
+
+                        # 3.2.1 Create upload job
+                        tbytes = 0
+                        position = 0
+                        chunk_aux = list()
+                        remainder = file_size % self.chunk_size
+                        nchunks = file_size // self.chunk_size
+                        tchunks = nchunks if remainder == 0 else nchunks + 1
+                        start = datetime.datetime.now()
+                        upload = directory.storage.create_upload(obj.name, file_size, obj.metadata)
+
+                        # 3.2.2 Upload chunks
+                        while tbytes < file_size:
+                            nbytes = self.chunk_size if position < nchunks else remainder
+                            metadata = obj.metadata.copy()
+                            c_start = datetime.datetime.now()
+                            try:
+                                aux = directory.storage.upload_chunk_from_file(obj.name,
+                                                                               upload,
+                                                                               position,
+                                                                               self.chunk_size,
+                                                                               input_file,
+                                                                               nbytes,
+                                                                               metadata)
+                            except:
+                                directory.storage.cancel_upload(obj.name, upload)
+                                raise
+
+                            chunk_aux.append({"position": position, "aux": aux})
+                            position += 1
+                            tbytes += nbytes
+                            c_elapsed = datetime.datetime.now() - c_start
+                            c_summary = get_transfer_summary(nbytes, c_elapsed)
+                            logging.info("Object [%s] successfully uploaded chunk: %d of %d. "
+                                         "Total bytes processed: %d of %d. %s" %
+                                         (obj.name, position, tchunks, tbytes, file_size, c_summary))
+
+                        # 3.2.3 Finalize upload job
+                        version = directory.storage.finalize_upload(obj.name, upload, chunk_aux, obj.metadata)
+                        elapsed = datetime.datetime.now() - start
+                        summary = get_transfer_summary(tbytes, elapsed)
+                        logging.info("Chunked upload of file [%s] successful. %s" % (file_path, summary))
+
+                # 3.3 Post-transfer database updates
+                # We only care about storing the returned aux version in the non-filesystem backend case
+                version = version if self.backend != "filesystem" else None
+                directory.version_aux_version_update(obj, version)
+                # On a successful transfer, we will automatically delete the aux redirect url
+                directory.version_aux_url_delete(obj)
+                success = True
+            except Exception as e:
+                logging.error("Error during transfer of [%s] to backend storage: %s" %
+                              (file_path, format_exception(e)))
+                continue
+            finally:
+                if input_file:
+                    input_file.close()
+                if success:
+                    shutil.rmtree(output_dir)
+
+    def main(self):
+        try:
+            import pydevd_pycharm
+            pydevd_pycharm.settrace('98.149.8.115', port=50006, stdoutToServer=True, stderrToServer=True)
+        except Exception as e:
+            sys.stderr.write(format_exception(e) + "\n")
+            sys.exit(-1)
+
+        args = self.parse_cli()
+        self.path_prefix = args.path_prefix
+        self.chunk_size *= args.chunk_size_multiplier
+        if args.cache_dir:
+            self.cache_dir = os.path.join(args.cache_dir, self.cache_dir_name)
+
+        # credential initialization
+        token = args.token if args.token else None
+        oauth2_token = args.oauth2_token if args.oauth2_token else None
+        credential_file = args.credential_file if args.credential_file else None
+        if credential_file:
+            self.credentials = get_credential(self.hostname, credential_file)
+        elif token or oauth2_token:
+            self.credentials = format_credential(token=token, oauth2_token=oauth2_token)
+
+        try:
+            # This will generally fail unless run locally in ~/hatrac on the target hatrac system for the migration
+            from hatrac import directory
+            self.backend = config.get('storage_backend')
+
+            # The "link_redirects" logic will set alternate "redirect" URLs for every object version in the database
+            # based on the following path components:
+            # <host> + <path-prefix> + <existing object name from the database name table>.
+            # The server will then automatically redirect requests for these objects to these URLs.
+            if args.link_redirects:
+                if not args.host:
+                    raise argparse.ArgumentError(
+                        None, 'The "--host" argument is required when the "--link-redirects" argument is specified.')
+                base_url = (args.host if args.host.startswith("http") else "https://" + args.host) + self.path_prefix
+                directory.version_aux_url_bulk_update(base_url)
+
+            # The "transfer_linked_redirects" logic will attempt to transfer files referenced by any pre-existing
+            # redirect links to the "local" hatrac instance. This could involve local file caching when additional IO
+            # is performed to backend storage off system, e.g. to S3.
+            if args.transfer_linked_redirects:
+                self.transfer_linked_objects(directory)
+            return 0
+        except argparse.ArgumentError as e:
+            logging.error(format_exception(e))
+        except RuntimeError as e:
+            logging.error(format_exception(e))
+            if args.debug:
+                traceback.print_exc()
+        except:
+            logging.error("Unhandled exception!")
+            traceback.print_exc()
+        return 1
+
+
+def main():
+    return HatracMigrateCLI(DESC, INFO, VERSION).main()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/hatrac-migrate
+++ b/bin/hatrac-migrate
@@ -226,13 +226,6 @@ class HatracMigrateCLI (BaseCLI):
                     shutil.rmtree(output_dir)
 
     def main(self):
-        try:
-            import pydevd_pycharm
-            pydevd_pycharm.settrace('98.149.8.115', port=50006, stdoutToServer=True, stderrToServer=True)
-        except Exception as e:
-            sys.stderr.write(format_exception(e) + "\n")
-            sys.exit(-1)
-
         args = self.parse_cli()
         self.path_prefix = args.path_prefix
         self.chunk_size *= args.chunk_size_multiplier

--- a/bin/hatrac-utils
+++ b/bin/hatrac-utils
@@ -32,9 +32,6 @@ class HatracUtilsCLI (BaseCLI):
     def __init__(self, description, epilog, version):
         super(HatracUtilsCLI, self).__init__(description, epilog, version)
 
-        import pydevd_pycharm
-        pydevd_pycharm.settrace('98.149.8.115', port=50006, stdoutToServer=True, stderrToServer=True)
-
         self.backend = None
         self.path_prefix = "/hatrac"
 

--- a/bin/hatrac-utils
+++ b/bin/hatrac-utils
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+#
+# Copyright 2015-2021 University of Southern California
+# Distributed under the Apache License, Version 2.0. See LICENSE for more info.
+#
+import os
+import sys
+import datetime
+import argparse
+import logging
+import pytz
+import traceback
+from hatrac.core import config
+
+# do a run-time import of deriva-py so that we don't need to declare it as a formal dependency
+try:
+    from deriva.core import format_exception, format_credential, BaseCLI
+except ModuleNotFoundError:
+    sys.stderr.write("Cannot import deriva.core python module. Ensure that deriva-py is installed.\n\n")
+    sys.exit(2)
+
+
+DESC = "DERIVA HATRAC Utilities Tool"
+INFO = "For more information see: https://github.com/informatics-isi-edu/hatrac"
+VERSION = 0.1
+
+
+class HatracUtilsCLI (BaseCLI):
+    """Deriva Hatrac Utilities Tool CLI.
+    """
+
+    def __init__(self, description, epilog, version):
+        super(HatracUtilsCLI, self).__init__(description, epilog, version)
+
+        import pydevd_pycharm
+        pydevd_pycharm.settrace('98.149.8.115', port=50006, stdoutToServer=True, stderrToServer=True)
+
+        self.backend = None
+        self.path_prefix = "/hatrac"
+
+        # parent arg parser
+        self.remove_options(['--host', '--token', '--oauth2-token', '--config-file', '--credential-file'])
+        subparsers = self.parser.add_subparsers(title='sub-commands', dest='subcmd')
+
+        # delete-upload-jobs parser
+        del_jobs_parser = subparsers.add_parser('del-jobs', help="Delete upload jobs.")
+        del_jobs_parser.add_argument("--namespace-root", metavar="<path>", type=str, default="/",
+                                     help="Namespace root path; default = \"/\".")
+        del_jobs_parser.add_argument("--older-than-days", metavar="<days>", type=int,
+                                     help="Only delete jobs older than <n> days.")
+        del_jobs_parser.add_argument("--include-orphans", action="store_true",
+                                     help="For certain backends (e.g. S3) which may have additional job metadata "
+                                          "records that may have orphaned relations from the Hatrac database, or no"
+                                          "correlating record at all, also delete these jobs from the target backend.")
+        del_jobs_parser.set_defaults(func=self.delete_upload_jobs)
+
+    def delete_upload_jobs(self, args):
+        self.backend = config.get('storage_backend')
+        try:
+            from hatrac import directory  # Must be run locally in ~/hatrac on the target hatrac system.
+
+            root = directory.name_resolve(args.namespace_root)
+            uploads = directory.namespace_enumerate_uploads(root)
+            if args.older_than_days is not None:
+                for upload in uploads:
+                    purge_threshold = datetime.datetime.now(tz=pytz.UTC) - \
+                                      datetime.timedelta(days=args.older_than_days)
+                    if purge_threshold > upload.created_on:
+                        try:
+                            directory._upload_cancel(upload)
+                            logging.info("Cancelled upload job %s created on %s" %
+                                         (upload.job, upload.created_on.isoformat()))
+                        except Exception as e:
+                            logging.warning("Exception while attempting to cancel upload job %s: %s" %
+                                            (upload.job, format_exception(e)))
+
+            if args.include_orphans:
+                if self.backend == "amazons3":
+                    directory.storage.purge_all_multipart_uploads(root.name)
+
+        except Exception as e:
+            raise RuntimeError(
+                "Exception while deleting upload jobs from the database: %s" % format_exception(e))
+
+    def main(self):
+        args = self.parse_cli()
+
+        if not hasattr(args, 'func'):
+            self.parser.print_usage()
+            return 1
+
+        try:
+            args.func(args)
+            return 0
+        except argparse.ArgumentError as e:
+            logging.error(format_exception(e))
+        except RuntimeError as e:
+            logging.error(format_exception(e))
+            if args.debug:
+                traceback.print_exc()
+        except:
+            logging.error("Unhandled exception!")
+            traceback.print_exc()
+        return 1
+
+
+def main():
+    return HatracUtilsCLI(DESC, INFO, VERSION).main()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hatrac/core.py
+++ b/hatrac/core.py
@@ -21,6 +21,9 @@ config = merge_config(
     jsonFileName='hatrac_config.json'
 )
 
+max_request_payload_size_default = 1024 * 1024 * 128  # ~135MB
+
+
 def coalesce(*args):
     for arg in args:
         if arg is not None:

--- a/hatrac/core.py
+++ b/hatrac/core.py
@@ -124,7 +124,7 @@ def _test_content_disposition(orig):
 class MetadataValue (str):
     def is_object(self):
         return False
-    
+
     def get_content(self, client_context, get_data=True):
         self.container.resource.enforce_acl(['owner', 'ancestor_owner'], client_context)
         body = self + '\n'
@@ -281,5 +281,14 @@ class Metadata (dict):
     def pop(self, k):
         k = k.lower()
         return dict.pop(self, k)
-        
-        
+
+
+class Redirect(object):
+    def __init__(self, url):
+        assert url
+        self.redirect_url = url
+
+    @property
+    def url(self):
+        return self.redirect_url
+

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -415,6 +415,7 @@ class HatracUpload (HatracName):
         self.job = args['job']
         self.nbytes = args['nbytes']
         self.chunksize = args['chunksize']
+        self.created_on = args['created_on']
 
     def __str__(self):
         return "%s;upload/%s" % (self.object, self.job)
@@ -1163,6 +1164,11 @@ ALTER TABLE hatrac.%(table)s ALTER COLUMN metadata SET NOT NULL;
 
     @db_wrap(reload_pos=1, enforce_acl=(1, 2, ['owner', 'ancestor_owner']), transform=lambda thunk: thunk())
     def upload_cancel(self, upload, client_context, conn=None, cur=None):
+        self._delete_upload(conn, cur, upload)
+        return lambda : self.storage.cancel_upload(upload.name, upload.job)
+
+    @db_wrap(reload_pos=1, transform=lambda thunk: thunk())
+    def _upload_cancel(self, upload, conn=None, cur=None):
         self._delete_upload(conn, cur, upload)
         return lambda : self.storage.cancel_upload(upload.name, upload.job)
 

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -54,7 +54,7 @@ from psycopg2.extras import DictCursor
 
 from webauthn2.util import jsonWriter, negotiated_content_type
 
-from ...core import coalesce, Metadata, sql_literal, sql_identifier
+from ...core import coalesce, Metadata, sql_literal, sql_identifier, Redirect
 from ... import core
 
 def regexp_escape(s):
@@ -363,9 +363,15 @@ class HatracObjectVersion (HatracName):
         return True
 
     def get_content(self, client_context, get_data=True):
+        aux_url = self.aux.get("url")
+        if aux_url:
+            return Redirect(aux_url)
         return self.directory.get_version_content(self.object, self, client_context, get_data)
 
     def get_content_range(self, client_context, get_slice=None, get_data=True):
+        aux_url = self.aux.get("url")
+        if aux_url:
+            return Redirect(aux_url)
         return self.directory.get_version_content_range(self.object, self, get_slice, client_context, get_data)
 
     def delete(self, client_context):

--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -343,7 +343,7 @@ class HatracObjectVersion (HatracName):
         self.object = object
         self.version = args['version']
         self.nbytes = args['nbytes']
-        self.aux = args['aux']
+        self.aux = args['aux'] or {}
 
     def __str__(self):
         return '%s:%s' % (self.object, self.version)

--- a/hatrac/model/storage/amazons3.py
+++ b/hatrac/model/storage/amazons3.py
@@ -159,11 +159,11 @@ class HatracStorage (PooledS3BucketConnection):
 
         return sendfunc(inp, nbytes, md5, content_type=content_type)
 
-    def get_content(self, name, version, metadata={}):
-        return self.get_content_range(name, version, metadata, None)
+    def get_content(self, name, version, metadata={}, aux={}):
+        return self.get_content_range(name, version, metadata, None, aux=aux)
      
     @s3_bucket_wrap(deferred_conn_reuse=True)
-    def get_content_range(self, name, version, metadata={}, get_slice=None, s3_session=None):
+    def get_content_range(self, name, version, metadata={}, get_slice=None, s3_session=None, aux={}):
         bucket_name, object_name = self._map_name(name)
         s3_bucket = s3_session.Bucket(bucket_name)
         s3_obj = s3_bucket.Object(object_name)
@@ -201,7 +201,7 @@ class HatracStorage (PooledS3BucketConnection):
         return length, metadata, data_generator(s3_session)
 
     @s3_bucket_wrap()
-    def delete(self, name, version, s3_session=None):
+    def delete(self, name, version, s3_session=None, aux={}):
         """Delete object version."""
         bucket_name, object_name = self._map_name(name)
         s3_bucket = s3_session.Bucket(bucket_name)

--- a/hatrac/model/storage/amazons3.py
+++ b/hatrac/model/storage/amazons3.py
@@ -184,7 +184,7 @@ class HatracStorage(PooledS3BucketConnection):
         nbytes = s3_obj.content_length
 
         over_threshold = False
-        presigned_url_threshold = bucket_config.get("presigned_url_threshold")
+        presigned_url_threshold = bucket_config.get("presigned_url_size_threshold")
         if isinstance(presigned_url_threshold, int) and presigned_url_threshold > 0:
             if nbytes > presigned_url_threshold:
                 over_threshold = True
@@ -195,7 +195,7 @@ class HatracStorage(PooledS3BucketConnection):
                 client = s3_session.meta.client
             url = client.generate_presigned_url(
                 ClientMethod='get_object',
-                ExpiresIn=300,
+                ExpiresIn=bucket_config.get("presigned_url_expiration_secs", 300),
                 Params={
                     'Bucket': bucket_name,
                     'Key': object_name,

--- a/hatrac/model/storage/amazons3.py
+++ b/hatrac/model/storage/amazons3.py
@@ -313,11 +313,8 @@ class HatracStorage(PooledS3BucketConnection):
                 try:
                     client.abort_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id)
                 except Exception as e:
-                    if "hatrac_request_trace" in web.ctx:
-                        web.ctx.hatrac_request_trace("S3 client error: %s" % e)
-                    else:
-                        sys.stderr.print("Error purging S3 multipart upload for Key [%s] with UploadId [%s]: %s" %
-                                         (key, upload_id, e))
+                    sys.stderr.print("Error purging S3 multipart upload for Key [%s] with UploadId [%s]: %s" %
+                                     (key, upload_id, e))
 
             if upload_response["IsTruncated"]:
                 next_key_marker = upload_response["NextKeyMarker"]

--- a/hatrac/model/storage/filesystem.py
+++ b/hatrac/model/storage/filesystem.py
@@ -187,10 +187,10 @@ class HatracStorage (object):
 
         return "test"
                
-    def get_content(self, name, version, metadata={}):
-        return self.get_content_range(name, version, metadata)
+    def get_content(self, name, version, metadata={}, aux={}):
+        return self.get_content_range(name, version, metadata, aux=aux)
      
-    def get_content_range(self, name, version, metadata={}, get_slice=None):
+    def get_content_range(self, name, version, metadata={}, get_slice=None, aux={}):
         """Return (nbytes, metadata, data_iterator) tuple for existing file-version object."""
         dirname, relname = self._dirname_relname(name, version)
         fullname = "%s/%s" % (dirname, relname)
@@ -248,7 +248,7 @@ class HatracStorage (object):
 
         return (length, metadata, helper())
 
-    def delete(self, name, version):
+    def delete(self, name, version, aux={}):
         """Delete object version."""
         dirname, relname = self._dirname_relname(name, version)
         fullname = "%s/%s" % (dirname, relname)

--- a/hatrac/rest/__init__.py
+++ b/hatrac/rest/__init__.py
@@ -9,6 +9,7 @@ import itertools
 import web
 import urllib
 
+import hatrac.core
 from . import core
 
 # these modify core.dispatch_rules
@@ -28,6 +29,9 @@ rules = [
     (re.compile(pattern + (pattern[-1] != '$' and '$' or '')), handler)
     for pattern, handler in rules
 ]
+
+read_only = hatrac.core.config.get("read_only", False)
+
 
 class Dispatcher (object):
     """Helper class to handle parser-based URL dispatch
@@ -68,12 +72,18 @@ class Dispatcher (object):
         return self.METHOD('GET')
         
     def PUT(self):
+        if read_only:
+            raise core.NoMethod("System is currently in read-only mode.")
         return self.METHOD('PUT')
 
     def DELETE(self):
+        if read_only:
+            raise core.NoMethod("System is currently in read-only mode.")
         return self.METHOD('DELETE')
 
     def POST(self):
+        if read_only:
+            raise core.NoMethod("System is currently in read-only mode.")
         return self.METHOD('POST')
 
 

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -34,6 +34,7 @@ from .. import directory
 
 _webauthn2_manager = webauthn2.Manager()
 
+
 def hash_value(d):
     return base64.b64encode(hashlib.md5(d.encode()).digest()).decode()
 
@@ -168,6 +169,11 @@ class LengthRequired (RestException):
 class PreconditionFailed (RestException):
     status = '412 Precondition Failed'
     message = 'Resource state does not match requested preconditions.'
+
+class PayloadTooLarge (RestException):
+    status = '413 Payload Too Large'
+    message = 'Request body size is larger than the current limit defined by the server, which is %s bytes.' % \
+              core.config.get("max_request_payload_size", core.max_request_payload_size_default)
 
 class BadRange (RestException):
     status = '416 Requested Range Not Satisfiable'

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -535,6 +535,21 @@ class RestHandler (object):
         web.ctx.hatrac_content_type = 'none'
         return ''
 
+    def redirect_response(self, redirect):
+        """Form response for redirect."""
+        assert isinstance(redirect, core.Redirect)
+        web.header('Location', redirect.url)
+        web.ctx.status = '303 See Other'
+        content_type = 'text/uri-list'
+        web.header('Content-Type', content_type)
+        web.ctx.hatrac_content_type = content_type
+        body = redirect.url + '\n'
+        nbytes = len(body)
+        web.header('Content-Length', nbytes)
+        web.ctx.hatrac_request_content_range = '*/%d' % nbytes
+        return body
+
+
     @web_method()
     def GET(self, *args):
         """Get resource."""

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -50,10 +50,13 @@ class NameVersion (RestHandler):
         self.http_check_preconditions()
         if self.get_body is False and resource.is_object():
             web.header("Accept-Ranges", "bytes")
-        return self.get_content(
+        response = self.get_content(
             resource,
             web.ctx.webauthn2_context
         )
+        if isinstance(response, core.Redirect):
+            return self.redirect_response(response)
+        return response
 
 @web_url([
      # path, name, querystr
@@ -211,8 +214,11 @@ class Name (RestHandler):
         self.http_check_preconditions()
         if self.get_body is False and resource.is_object():
             web.header("Accept-Ranges", "bytes")
-        return self.get_content(
+        response = self.get_content(
             resource,
             web.ctx.webauthn2_context
         )
+        if isinstance(response, core.Redirect):
+            return self.redirect_response(response)
+        return response
 

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -11,7 +11,8 @@
 import web
 
 from .. import core
-from .core import web_url, web_method, RestHandler, NoMethod, Conflict, BadRequest, NotFound, LengthRequired, hash_list
+from .core import web_url, web_method, RestHandler, NoMethod, Conflict, BadRequest, NotFound, LengthRequired, \
+    PayloadTooLarge, hash_list
 
 @web_url([
      # path, name, version, querystr
@@ -151,6 +152,9 @@ class Name (RestHandler):
                 nbytes = int(web.ctx.env['CONTENT_LENGTH'])
             except:
                 raise LengthRequired()
+
+            if nbytes > core.config.get("max_request_payload_size", core.max_request_payload_size_default):
+                raise PayloadTooLarge()
 
             metadata = { 'content-type': in_content_type }
             

--- a/hatrac/rest/transfer.py
+++ b/hatrac/rest/transfer.py
@@ -10,7 +10,8 @@ import web
 from webauthn2.util import jsonReader
 
 from .. import core
-from .core import web_url, web_method, RestHandler, NoMethod, Conflict, NotFound, BadRequest, LengthRequired
+from .core import web_url, web_method, RestHandler, NoMethod, Conflict, NotFound, BadRequest, LengthRequired, \
+    PayloadTooLarge
 
 @web_url([
     # path, name, job, chunk, querystr
@@ -37,6 +38,9 @@ class ObjectTransferChunk (RestHandler):
             nbytes = int(web.ctx.env['CONTENT_LENGTH'])
         except:
             raise LengthRequired()
+
+        if nbytes > core.config.get("max_request_payload_size", core.max_request_payload_size_default):
+            raise PayloadTooLarge()
 
         metadata = {}
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version="0.3",
     packages=["hatrac", "hatrac.model", "hatrac.model.directory", "hatrac.model.storage", "hatrac.rest"],
     package_data={'hatrac': ["*.wsgi"]},
-    scripts=["bin/hatrac-deploy", "bin/hatrac-migrate"],
+    scripts=["bin/hatrac-deploy", "bin/hatrac-migrate", "bin/hatrac-utils"],
     requires=["web", "psycopg2", "webauthn2", "boto3", "botocore"],
     maintainer_email="isrd-support@isi.edu",
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ from setuptools import setup
 setup(
     name="hatrac",
     description="simple object storage service",
-    version="0.2",
+    version="0.3",
     packages=["hatrac", "hatrac.model", "hatrac.model.directory", "hatrac.model.storage", "hatrac.rest"],
     package_data={'hatrac': ["*.wsgi"]},
-    scripts=["bin/hatrac-deploy"],
+    scripts=["bin/hatrac-deploy", "bin/hatrac-migrate"],
     requires=["web", "psycopg2", "webauthn2", "boto3", "botocore"],
     maintainer_email="isrd-support@isi.edu",
     license='Apache 2.0',


### PR DESCRIPTION
This PR includes updates for the S3 backend along with the implementation of a generic redirection response that can be used for various scenarios, such as:
1. Trickle migration from one Hatrac instance to another.
2. Maintaining "sparse" copies of assets where some objects are managed by the instance and others are remote links to be redirected.
3. Creating S3 presigned-urls and redirecting clients to the S3-native URL rather than proxying the transfer from S3 on behalf of the client.

Two new utilities are provided; `hatrac-migrate` and `hatrac-utils`, which are CLI tools that are meant to be invoked under the privileged `hatrac` system account directly on the server instance they are intended to operate against. 

1. The `hatrac-migrate` tool provides functions for bulk setting the `aux` URL metadata element for use with redirection to a specified source server, along with the ability to transfer resources from that source server to the local instance for partial or full object migration.
2. The `hatrac-utils` tool is meant to be a generic tool for performing maintenance functions against the local server instance. Currently, only one function is implemented, `del-jobs` which can be used to both cleanup incomplete transfer jobs older than a specified number of days, and also purge any multipart uploads from the S3 backend, which may (for whatever reason) have become orphaned from job entries in the database.

Additional notes:

1. S3 presigned-url behavior is governed by two parameters, configured at the path-to-bucket mapping level: `presigned_url_size_threshold` and `presigned_url_expiration_secs`. The `presigned_url_size_threshold` is the size in bytes that the object must be greater than to have a presigned URL generated for it, while the `presigned_url_expiration_secs` is the validity duration for the presigned url, in seconds. The `presigned_url_size_threshold` _must_ be specified with an integer value greater than zero in order to trigger S3 URL presigning. The `presigned_url_expiration_secs` argument is optional and defaults to `300` if not specified.

2. An additional server configuration variable has been added, `read-only` which when enabled will reject PUT, POST, and DELETE methods with a `405 Method Not Allowed` response. This setting is intended for use on the source server in a migration, to ensure source data is not able to be mutated while the migration is in progress.

Future improvements:

1. Concurrent transfers during migration process.
2. More control over the migration process via a configuration file. For instance, it may be desirable to enumerate a set of objects for transfer migration up-front, and have the remainder be redirected to the original source.
3. Migration of objects and metadata from non-Hatrac sources, e.g. "in-place" creation of Hatrac objects from an existing S3 bucket or other storage system, e.g. a Globus endpoint.