### PR TITLE
Refactored AWS S3 backend to use low-level boto3 `client` API vs...

### DIFF
--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -1158,7 +1158,12 @@ ALTER TABLE hatrac.%(table)s ALTER COLUMN metadata SET NOT NULL;
         if objversion.is_deleted:
             raise core.NotFound('Resource %s is not available.' % objversion)
         if get_data:
-            nbytes, metadata, data = self.storage.get_content_range(object.name, objversion.version, objversion.metadata, get_slice, objversion.aux)
+            nbytes, metadata, data = self.storage.get_content_range(object.name,
+                                                                    objversion.version,
+                                                                    objversion.metadata,
+                                                                    get_slice,
+                                                                    objversion.aux,
+                                                                    objversion.nbytes)
         else:
             nbytes = objversion.nbytes
             metadata = objversion.metadata

--- a/hatrac/model/storage/amazons3.py
+++ b/hatrac/model/storage/amazons3.py
@@ -90,6 +90,9 @@ class HatracStorage:
         self.s3_default_session = boto3.session.Session(
             **self.s3_config.get('default_session', self.s3_config.get('session', dict())))
         self.s3_bucket_mappings = self.s3_config.get("bucket_mappings", self.s3_config.get('buckets', dict()))
+        for bucket_mapping in self.s3_bucket_mappings.values():
+            if not bucket_mapping.get("conn"):
+                bucket_mapping["conn"] = S3BucketConnection(bucket_mapping, self.s3_default_session)
 
     def _map_name(self, name):
         object_name = name.lstrip("/")
@@ -105,9 +108,6 @@ class HatracStorage:
             if not prefix.endswith("/"):
                 prefix += "/"
             object_name = "%s%s" % (prefix, object_name)
-
-        if not bucket_mapping.get("conn"):
-            bucket_mapping["conn"] = S3BucketConnection(bucket_mapping, self.s3_default_session)
 
         return S3ConnInfo(bucket_name,
                           object_name,

--- a/hatrac/model/storage/filesystem.py
+++ b/hatrac/model/storage/filesystem.py
@@ -190,7 +190,7 @@ class HatracStorage (object):
     def get_content(self, name, version, metadata={}, aux={}):
         return self.get_content_range(name, version, metadata, aux=aux)
      
-    def get_content_range(self, name, version, metadata={}, get_slice=None, aux={}):
+    def get_content_range(self, name, version, metadata={}, get_slice=None, aux={}, version_bytes=None):
         """Return (nbytes, metadata, data_iterator) tuple for existing file-version object."""
         dirname, relname = self._dirname_relname(name, version)
         fullname = "%s/%s" % (dirname, relname)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 setup(
     name="hatrac",
     description="simple object storage service",
-    version="0.3",
+    version="0.4",
     packages=["hatrac", "hatrac.model", "hatrac.model.directory", "hatrac.model.storage", "hatrac.rest"],
     package_data={'hatrac': ["*.wsgi"]},
     scripts=["bin/hatrac-deploy", "bin/hatrac-migrate", "bin/hatrac-utils"],


### PR DESCRIPTION
…`resource` API, due to resource API not being actively developed anymore and not being completely thread-safe.

Reworked connection handling and bucket/object name mapping configuration in order to better support non-AWS S3 providers like Wasabi and Minio. These changes allow for mapping hatrac namespace paths to multiple buckets backed by possibly different S3-compatible storage providers, all in the same instance.