### PR TITLE
Flask firewall

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -99,6 +99,26 @@ This configuration works for an Amazon AWS S3 deployment:
         "database_max_retries": 5
     }
 
+This configuration block enables an optional static firewall to require clients
+to have certain attributes in order to perform certain operations:
+
+    {
+        ...
+        "firewall_acls": {
+            "create": ["object-or-ns-uploader-group"],
+            "delete": ["object-or-ns-deletion-group"],
+            "manage_acls": ["acl-admin-group"],
+            "manage_metadata": ["metadata-curator-group"]
+        }
+    }
+
+For backwards compatibility, `firewall_acls` uses a default ACL of
+`["*"]` when an ACL is not configured. This permissive mode then
+allows the normal fine-grained authorization checks to proceed for
+each request.  A more restrictive firewall ACL can block a request
+that would normally be allowed due to the fine-grained ACL state in
+the hatrac namespace hierarchy.
+
 ## REST API testing
 
 You can perform system testing of the whole web service stack, if

--- a/hatrac/model/storage/overlay.py
+++ b/hatrac/model/storage/overlay.py
@@ -111,6 +111,9 @@ class HatracStorage (object):
 
     # method params are passed by position from hatrac.model.directory.pgsql
     # except where specifically proxied as param=value below
+    @property
+    def track_chunks(self):
+        return self.backends[0].track_chunks
 
     def create_from_file(self, name, input, nbytes, metadata={}):
         return self.backends[0].create_from_file(name, input, nbytes, metadata)

--- a/hatrac/rest/acl.py
+++ b/hatrac/rest/acl.py
@@ -19,6 +19,7 @@ class ACLEntry (RestHandler):
 
     def put(self, access, role, path="/", name="", version=""):
         """Add entry to ACL."""
+        self.enforce_firewall('manage_acl')
         resource = self.resolve_name_or_version(
             path, name, version
         )
@@ -33,6 +34,7 @@ class ACLEntry (RestHandler):
 
     def delete(self, access, role, path="/", name="", version=""):
         """Remove entry from ACL."""
+        self.enforce_firewall('manage_acl')
         resource = self.resolve_name_or_version(
             path, name, version
         )
@@ -74,6 +76,7 @@ class ACL (RestHandler):
 
     def put(self, access, path="/", name="", version=""):
         """Replace ACL."""
+        self.enforce_firewall('manage_acl')
         in_content_type = self.in_content_type()
         if in_content_type != 'application/json':
             raise BadRequest('Only application/json input is accepted for ACLs.')
@@ -100,6 +103,7 @@ class ACL (RestHandler):
 
     def delete(self, access, path="/", name="", version=""):
         """Clear ACL."""
+        self.enforce_firewall('manage_acl')
         resource = self.resolve_name_or_version(
             path, name, version
         )

--- a/hatrac/rest/core.py
+++ b/hatrac/rest/core.py
@@ -33,7 +33,7 @@ from webauthn2.rest import format_trace_json, format_final_json
 
 from . import app
 from .. import core
-from ..core import hatrac_debug, negotiated_content_type
+from ..core import hatrac_debug, negotiated_content_type, set_acl_match_attributes
 from .. import directory
 
 _webauthn2_manager = Manager()
@@ -236,7 +236,9 @@ def before_request():
         directory.prefix = request.environ['SCRIPT_NAME']
 
     # get client authentication context
-    hatrac_ctx.webauthn2_context = context_from_environment(request.environ, fallback=True)
+    client_context = context_from_environment(request.environ, fallback=True)
+    set_acl_match_attributes(client_context)
+    hatrac_ctx.webauthn2_context = client_context
 
     return None
 
@@ -308,6 +310,17 @@ class RestHandler (flask.views.MethodView):
         self.get_body = True
         self.http_etag = None
         self.http_vary = _webauthn2_manager.get_http_vary()
+
+    @classmethod
+    def enforce_firewall(cls, aclname):
+        # see hatrac.core for built-in firewall_acls
+        acl = core.config.get("firewall_acls")[aclname]
+        if not acl.isdisjoint(hatrac_ctx.webauthn2_context.acl_match_attributes):
+            return True
+        elif hatrac_ctx.webauthn2_context.client is not None:
+            raise core.Forbidden('%s access forbidden.' % aclname)
+        else:
+            raise core.Unauthenticated('Authentication required for %s access' % aclname)
 
     def trace(self, msg):
         hatrac_ctx.hatrac_request_trace(msg)

--- a/hatrac/rest/metadata.py
+++ b/hatrac/rest/metadata.py
@@ -18,6 +18,7 @@ class Metadata (RestHandler):
 
     def put(self, fieldname, path="/", name="", version=""):
         """Replace Metadata value."""
+        self.enforce_firewall('manage_metadata')
         in_content_type = self.in_content_type()
         if in_content_type != 'text/plain':
             raise BadRequest('Only text/plain input is accepted for metadata.')
@@ -43,6 +44,7 @@ class Metadata (RestHandler):
 
     def delete(self, fieldname, path="/", name="", version=""):
         """Clear Metadata value."""
+        self.enforce_firewall('manage_metadata')
         if version:
             resource = self.resolve_version(path, name, version)
         else:

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -27,6 +27,7 @@ class NameVersion (RestHandler):
 
     def delete(self, name, version, path=''):
         """Destroy object version."""
+        self.enforce_firewall('delete')
         resource = self.resolve_version(
             path, name, version
         )
@@ -108,6 +109,7 @@ class Name (RestHandler):
 
     def put(self, name="", path="/"):
         """Create object version or empty zone."""
+        self.enforce_firewall('create')
         in_content_type = self.in_content_type()
         
         resource = self.resolve(path, name, False)
@@ -133,7 +135,7 @@ class Name (RestHandler):
                 hash_list([ r.asurl() for r in resource.directory.namespace_enumerate_names(resource, False, False)])
             )
             self.http_check_preconditions('PUT')
-            resource.enforce_acl(['owner'], hatrac_ctx.webauthn2_context)
+            resource.enforce_acl(['owner'])
             raise Conflict('Namespace %s already exists.' % resource)
         else:
             try:
@@ -177,6 +179,7 @@ class Name (RestHandler):
 
     def delete(self, name="", path="/"):
         """Destroy all object versions or empty zone."""
+        self.enforce_firewall('delete')
         resource = self.resolve(
             path, name
         )

--- a/hatrac/rest/transfer.py
+++ b/hatrac/rest/transfer.py
@@ -47,7 +47,7 @@ class ObjectTransferChunk (RestHandler):
                 metadata[hdr] = val
                 
         upload = self.resolve_upload(path, name, job)
-        upload.enforce_acl(['owner'], hatrac_ctx.webauthn2_context)
+        upload.enforce_acl(['owner'])
         self.http_check_preconditions('PUT')
         upload.upload_chunk_from_file(
             chunk, 
@@ -77,6 +77,7 @@ class ObjectTransfer (RestHandler):
 
     def post(self, name, job, path="/"):
         """Update status of transfer job to finalize."""
+        self.enforce_firewall('create')
         upload = self.resolve_upload(path, name, job)
         self.http_check_preconditions('POST')
         version = upload.finalize(hatrac_ctx.webauthn2_context)
@@ -114,6 +115,7 @@ class ObjectTransfers (RestHandler):
 
     def post(self, name, path="/"):
         """Create a new chunked transfer job."""
+        self.enforce_firewall('create')
         in_content_type = self.in_content_type()
 
         if in_content_type != 'application/json':


### PR DESCRIPTION
Adds support for a "firewall_acls" configuration field. The default, backwards-compatible behavior acts like:
```
{
   ...
   "firewall_acls": {
      "create": ["*"],
      "delete": ["*"],
      "manage_acls": ["*"],
      "manage_metadata": ["*"]
   },
   ...
}
```
Which applies no further restrictions to the usual per-namespace or per-object access control logic. By adjusting these firewall ACLs to more limited lists of group or user IDs, certain hatrac requests can be denied even if the client would have permission based on the namespace or object ACLs.