### PR TITLE
add custom flask URL converters for path elements

### DIFF
--- a/hatrac/rest/__init__.py
+++ b/hatrac/rest/__init__.py
@@ -9,8 +9,20 @@ import re
 import itertools
 import urllib
 from flask import Flask, request
+from werkzeug.routing import BaseConverter
 
 from ..core import config
+
+class HatracPathElemConverter(BaseConverter):
+    """Hatrac-specific path elements are more limited than Flask
+    """
+    regex = '[^?/:;]+'
+
+class HatracPathConverter(BaseConverter):
+    """Hatrac-specific path elements are more limited than Flask
+    """
+    regex = '[^?/:;][^?:;]+'
+    weight = 200
 
 def raw_path_app(app_orig, raw_uri_env_key='REQUEST_URI'):
     """Allow routes to distinguish raw reserved chars from escaped ones.
@@ -31,6 +43,8 @@ def raw_path_app(app_orig, raw_uri_env_key='REQUEST_URI'):
 
 app = Flask(__name__)
 app.wsgi_app = raw_path_app(app.wsgi_app)
+app.url_map.converters['hstring'] = HatracPathElemConverter
+app.url_map.converters['hpath'] = HatracPathConverter
 
 read_only = config.get("read_only", False)
 # TODO: add method decorator for this!!

--- a/hatrac/rest/acl.py
+++ b/hatrac/rest/acl.py
@@ -55,15 +55,15 @@ class ACLEntry (RestHandler):
         return self.get_content(resource, hatrac_ctx.webauthn2_context)
 
 _ACLEntry_view = app.route(
-    '/;acl/<access>/<role>'
+    '/;acl/<hstring:access>/<hstring:role>'
 )(app.route(
-    '/<name>;acl/<access>/<role>'
+    '/<hstring:name>;acl/<hstring:access>/<hstring:role>'
 )(app.route(
-    '/<name>:<version>;acl/<access>/<role>'
+    '/<hstring:name>:<hstring:version>;acl/<hstring:access>/<hstring:role>'
 )(app.route(
-    '/<path:path>/<name>;acl/<access>/<role>'
+    '/<hpath:path>/<hstring:name>;acl/<hstring:access>/<hstring:role>'
 )(app.route(
-    '/<path:path>/<name>:<version>;acl/<access>/<role>'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;acl/<hstring:access>/<hstring:role>'
 )(ACLEntry.as_view('ACLEntry'))))))
 
 
@@ -120,25 +120,25 @@ class ACL (RestHandler):
         return self.get_content(resource, hatrac_ctx.webauthn2_context)
 
 _ACL_view = app.route(
-    '/;acl/<access>'
+    '/;acl/<hstring:access>'
 )(app.route(
-    '/;acl/<access>/'
+    '/;acl/<hstring:access>/'
 )(app.route(
-    '/<name>;acl/<access>'
+    '/<hstring:name>;acl/<hstring:access>'
 )(app.route(
-    '/<name>;acl/<access>/'
+    '/<hstring:name>;acl/<hstring:access>/'
 )(app.route(
-    '/<name>:<version>;acl/<access>'
+    '/<hstring:name>:<hstring:version>;acl/<hstring:access>'
 )(app.route(
-    '/<name>:<version>;acl/<access>/'
+    '/<hstring:name>:<hstring:version>;acl/<hstring:access>/'
 )(app.route(
-    '/<path:path>/<name>;acl/<access>'
+    '/<hpath:path>/<hstring:name>;acl/<hstring:access>'
 )(app.route(
-    '/<path:path>/<name>;acl/<access>/'
+    '/<hpath:path>/<hstring:name>;acl/<hstring:access>/'
 )(app.route(
-    '/<path:path>/<name>:<version>;acl/<access>'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;acl/<hstring:access>'
 )(app.route(
-    '/<path:path>/<name>:<version>;acl/<access>/'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;acl/<hstring:access>/'
 )(ACL.as_view('ACL')))))))))))
 
 
@@ -160,19 +160,19 @@ _ACLs_view = app.route(
 )(app.route(
     '/;acl/'
 )(app.route(
-    '/<name>;acl'
+    '/<hstring:name>;acl'
 )(app.route(
-    '/<name>;acl/'
+    '/<hstring:name>;acl/'
 )(app.route(
-    '/<name>:<version>;acl'
+    '/<hstring:name>:<hstring:version>;acl'
 )(app.route(
-    '/<name>:<version>;acl/'
+    '/<hstring:name>:<hstring:version>;acl/'
 )(app.route(
-    '/<path:path>/<name>;acl'
+    '/<hpath:path>/<hstring:name>;acl'
 )(app.route(
-    '/<path:path>/<name>;acl/'
+    '/<hpath:path>/<hstring:name>;acl/'
 )(app.route(
-    '/<path:path>/<name>:<version>;acl'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;acl'
 )(app.route(
-    '/<path:path>/<name>:<version>;acl/'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;acl/'
 )(ACLs.as_view('ACLs')))))))))))

--- a/hatrac/rest/metadata.py
+++ b/hatrac/rest/metadata.py
@@ -78,15 +78,15 @@ class Metadata (RestHandler):
         return self.get_content(resource, hatrac_ctx.webauthn2_context)
 
 _Metadata_view = app.route(
-    '/;metadata/<fieldname>'
+    '/;metadata/<hstring:fieldname>'
 )(app.route(
-    '/<name>;metadata/<fieldname>'
+    '/<hstring:name>;metadata/<hstring:fieldname>'
 )(app.route(
-    '/<name>:<version>;metadata/<fieldname>'
+    '/<hstring:name>:<hstring:version>;metadata/<hstring:fieldname>'
 )(app.route(
-    '/<path:path>/<name>;metadata/<fieldname>'
+    '/<hpath:path>/<hstring:name>;metadata/<hstring:fieldname>'
 )(app.route(
-    '/<path:path>/<name>:<version>;metadata/<fieldname>'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;metadata/<hstring:fieldname>'
 )(Metadata.as_view('Metadata'))))))
 
 class MetadataCollection (RestHandler):
@@ -116,20 +116,20 @@ _MetadataCollection_view = app.route(
 )(app.route(
     '/;metadata/'
 )(app.route(
-    '/<name>;metadata'
+    '/<hstring:name>;metadata'
 )(app.route(
-    '/<name>;metadata/'
+    '/<hstring:name>;metadata/'
 )(app.route(
-    '/<name>:<version>;metadata'
+    '/<hstring:name>:<hstring:version>;metadata'
 )(app.route(
-    '/<name>:<version>;metadata/'
+    '/<hstring:name>:<hstring:version>;metadata/'
 )(app.route(
-    '/<path:path>/<name>;metadata'
+    '/<hpath:path>/<hstring:name>;metadata'
 )(app.route(
-    '/<path:path>/<name>;metadata/'
+    '/<hpath:path>/<hstring:name>;metadata/'
 )(app.route(
-    '/<path:path>/<name>:<version>;metadata'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;metadata'
 )(app.route(
-    '/<path:path>/<name>:<version>;metadata/'
+    '/<hpath:path>/<hstring:name>:<hstring:version>;metadata/'
 )(MetadataCollection.as_view('MetadataCollection')))))))))))
 

--- a/hatrac/rest/name.py
+++ b/hatrac/rest/name.py
@@ -58,9 +58,9 @@ class NameVersion (RestHandler):
         return resp
 
 _NameVersion_view = app.route(
-    '/<name>:<version>'
+    '/<hstring:name>:<hstring:version>'
 )(app.route(
-    '/<path:path>/<name>:<version>'
+    '/<hpath:path>/<hstring:name>:<hstring:version>'
 )(NameVersion.as_view('NameVersion')))
 
 
@@ -91,9 +91,9 @@ class NameVersions (RestHandler):
 
 
 _NameVersions_view = app.route(
-    '/<name>;versions'
+    '/<hstring:name>;versions'
 )(app.route(
-    '/<path:path>/<name>;versions'
+    '/<hpath:path>/<hstring:name>;versions'
 )(NameVersions.as_view('NameVersions')))
 
 
@@ -229,11 +229,11 @@ class Name (RestHandler):
 _Name_view = app.route(
     '/'
 )(app.route(
-    '/<name>'
+    '/<hstring:name>'
 )(app.route(
-    '/<name>/'
+    '/<hstring:name>/'
 )(app.route(
-    '/<path:path>/<name>'
+    '/<hpath:path>/<hstring:name>'
 )(app.route(
-    '/<path:path>/<name>/'
+    '/<hpath:path>/<hstring:name>/'
 )(Name.as_view('Name'))))))

--- a/hatrac/rest/transfer.py
+++ b/hatrac/rest/transfer.py
@@ -64,9 +64,9 @@ class ObjectTransferChunk (RestHandler):
         raise NoMethod()
 
 _ObjectTransferChunk_view = app.route(
-    '/<name>;upload/<job>/<chunk>'
+    '/<hstring:name>;upload/<hstring:job>/<hstring:chunk>'
 )(app.route(
-    '/<path:path>/<name>;upload/<job>/<chunk>'
+    '/<hpath:path>/<hstring:name>;upload/<hstring:job>/<hstring:chunk>'
 )(ObjectTransferChunk.as_view('ObjectTransferChunk')))
 
 
@@ -97,13 +97,13 @@ class ObjectTransfer (RestHandler):
         return self.get_content(upload, hatrac_ctx.webauthn2_context)
 
 _ObjectTransfer_view = app.route(
-    '/<name>;upload/<job>'
+    '/<hstring:name>;upload/<hstring:job>'
 )(app.route(
-    '/<name>;upload/<job>/'
+    '/<hstring:name>;upload/<hstring:job>/'
 )(app.route(
-    '/<path:path>/<name>;upload/<job>'
+    '/<hpath:path>/<hstring:name>;upload/<hstring:job>'
 )(app.route(
-    '/<path:path>/<name>;upload/<job>/'
+    '/<hpath:path>/<hstring:name>;upload/<hstring:job>/'
 )(ObjectTransfer.as_view('ObjectTransfer')))))
 
 
@@ -183,11 +183,11 @@ class ObjectTransfers (RestHandler):
         return self.get_content(resource, hatrac_ctx.webauthn2_context)
 
 _ObjectTransfers_view = app.route(
-    '/<name>;upload'
+    '/<hstring:name>;upload'
 )(app.route(
-    '/<name>;upload/'
+    '/<hstring:name>;upload/'
 )(app.route(
-    '/<path:path>/<name>;upload'
+    '/<hpath:path>/<hstring:name>;upload'
 )(app.route(
-    '/<path:path>/<name>;upload/'
+    '/<hpath:path>/<hstring:name>;upload/'
 )(ObjectTransfers.as_view('ObjectTransfers')))))


### PR DESCRIPTION
The flask built-in converters for path and string are too permissive and can lead to ambiguous URL routing. We want to strictly limit our routing so that the separators of Hatrac URLs `[?/:;]` can never appear inside any of the basic strings that are being separated.