### PR TITLE
ACL mgmt url-decode fix

### DIFF
--- a/hatrac/model/directory/pgsql.py
+++ b/hatrac/model/directory/pgsql.py
@@ -95,7 +95,7 @@ class ACL (set):
     def __getitem__(self, role):
         if role not in self:
             raise core.NotFound(
-                'ACL member %s;acl/%s/%s not found.' % (self.resource, self.access, role)
+                'ACL member %s;acl/%s/%s not found.' % (self.resource, self.access, urllib.parse.quote(role, safe=''))
             )
         entry = ACLEntry(role + '\n')
         entry.resource = self.resource

--- a/hatrac/rest/acl.py
+++ b/hatrac/rest/acl.py
@@ -6,6 +6,7 @@
 
 import json
 from flask import request, g as hatrac_ctx
+from urllib.parse import unquote
 
 from . import app
 from .core import RestHandler, \
@@ -20,6 +21,7 @@ class ACLEntry (RestHandler):
     def put(self, access, role, path="/", name="", version=""):
         """Add entry to ACL."""
         self.enforce_firewall('manage_acl')
+        role = unquote(role)
         resource = self.resolve_name_or_version(
             path, name, version
         )
@@ -35,6 +37,7 @@ class ACLEntry (RestHandler):
     def delete(self, access, role, path="/", name="", version=""):
         """Remove entry from ACL."""
         self.enforce_firewall('manage_acl')
+        role = unquote(role)
         resource = self.resolve_name_or_version(
             path, name, version
         )
@@ -50,6 +53,7 @@ class ACLEntry (RestHandler):
     def get(self, access, role, path="/", name="", version=""):
         """Get entry from ACL."""
         self.get_body = False if request.method == 'HEAD' else True
+        role = unquote(role)
         resource = self.resolve_name_or_version(path, name, version).acls[access]
         self.set_http_etag(hash_list(resource))
         resource = resource[role]

--- a/test/rest-smoketest.sh
+++ b/test/rest-smoketest.sh
@@ -49,9 +49,17 @@ RESPONSE_HEADERS=/tmp/${RUNKEY}-response-headers
 RESPONSE_CONTENT=/tmp/${RUNKEY}-response-content
 TEST_DATA=/tmp/${RUNKEY}-test-data
 TEST_ACL_ANON=/tmp/${RUNKEY}-test-acl-anon.json
+TEST_ACL_URI=/tmp/${RUNKEY}-test-acl-uri.json
 
 cat > ${TEST_ACL_ANON} <<EOF
 ["*"]
+EOF
+
+test_acl_uri_member='scheme://authority/path'
+test_acl_uri_member_quoted='scheme%3A%2F%2Fauthority%2Fpath'
+
+cat > ${TEST_ACL_URI} <<EOF
+["unlikely value", "${test_acl_uri_member}"]
 EOF
 
 cleanup()
@@ -788,7 +796,12 @@ dotest "200::application/json::*" "/ns-${RUNKEY}/foo;acl/"
 dotest "200::application/json::*" "/ns-${RUNKEY}/foo;acl/owner"
 dotest "200::application/json::*" "/ns-${RUNKEY}/foo;acl/owner" --head
 dotest "200::application/json::*" "/ns-${RUNKEY}/foo;acl/create"
-dotest "404::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/DUMMY"
+dotest "204::*::*" "/ns-${RUNKEY}/foo/bar;acl/create" -T ${TEST_ACL_URI} -H "Content-Type: application/json"
+dotest "200::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/${test_acl_uri_member_quoted}"
+dotest "204::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/${test_acl_uri_member_quoted}" -X DELETE
+dotest "404::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/${test_acl_uri_member_quoted}"
+dotest "204::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/${test_acl_uri_member_quoted}" -X PUT
+dotest "200::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/${test_acl_uri_member_quoted}"
 dotest "204::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/DUMMY" -X PUT
 dotest "200::text/plain*::*" "/ns-${RUNKEY}/foo/bar;acl/create/DUMMY" --head
 dotest "204::*::*" "/ns-${RUNKEY}/foo/bar;acl/create/DUMMY" -X DELETE -H "If-Match: *"


### PR DESCRIPTION
Fixes a regression in the /hatrac/path/name;acl/access/entry  resources that allow addressing of individual entries in an access control list.

Since some time during the Flask port and general revision to how URLs are parsed and dispatched, these haven't been working as they need to. The entry value will be URL encoded, e.g. when it is a URI, but this needs to be decoded before it is mapped to the underlying ACL storage in the database.  It also needs to be re-encoded when generating a NotFound exception that names the specific ACL entry.

(This is different than namespace and object names which we keep encoded even in the database, and that's where the regression stems from.)